### PR TITLE
refactor: Remove global emulator reference from window

### DIFF
--- a/src/scripts/emulator-view.ts
+++ b/src/scripts/emulator-view.ts
@@ -43,7 +43,6 @@ export class EmulatorView {
       }
 
       this.emulator = new Emulator(this.canvas, model)
-      window.theEmulator = this.emulator
       await this.emulator.initialise()
       notifyHost({ command: ClientCommand.EmulatorReady })
 

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -48,7 +48,6 @@ window.addEventListener('message', (event) => {
     case HostCommand.LoadDisc:
       if (message.url) {
         console.log(`loadDisc=${message.url}`)
-        // window.theEmulator?.loadDisc(message.url)
         emulatorView?.emulator?.loadDisc(message.url)
       }
       break

--- a/src/scripts/types.ts
+++ b/src/scripts/types.ts
@@ -1,8 +1,8 @@
-import type { Emulator } from './emulator'
+// help typescript to understand this file is a module
+export {}
 
 declare global {
   interface Window {
-    theEmulator: Emulator | undefined
     JSBEEB_RESOURCES: Record<string, string>
     JSBEEB_DISC?: string
   }


### PR DESCRIPTION
No need for global emulator reference in window now