### PR TITLE
feat: Support sounds/audio

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -36,6 +36,12 @@ label {
 	width: 200px;
 }
 
+
+#audio-warning {
+  width: 480px;
+  margin: 8px;
+}
+
 /**
   * Infobar
   */

--- a/src/client/panels/emulator-panel.ts
+++ b/src/client/panels/emulator-panel.ts
@@ -154,7 +154,14 @@ export class EmulatorPanel {
 		${isFeatureEnabled('emulatorToolBar') ? this.getToolbarHtml() : ''}
 		${this.getEmulatorHtml()}
     ${this.getInfoBarHtml()}
-		${isDev() ? this.getTestHtml() : ''}
+
+  <vscode-button id="audio-warning" appearance="primary" hidden>
+    <span class="codicon codicon-warning"></span>
+    &nbsp;Audio is disabled in this webview. Click to enable.
+  </vscode-button>
+
+
+    ${isDev() ? this.getTestHtml() : ''}
 
 </body>
 </html>`
@@ -194,8 +201,7 @@ export class EmulatorPanel {
   getToolbarHtml() {
     return `
 
-
-	<div id="toolbar">
+  <div id="toolbar">
 
 		<vscode-button id="toolbar-control" appearance="secondary">
 			<span class="codicon codicon-debug-start"></span>

--- a/src/scripts/custom-audio-handler.ts
+++ b/src/scripts/custom-audio-handler.ts
@@ -1,0 +1,38 @@
+import { AudioHandler } from 'jsbeeb/web/audio-handler'
+
+/**
+ * CustomAudioHandler extends AudioHandler to add a couple of additional interfaces.
+ */
+export class CustomAudioHandler extends AudioHandler {
+  muted: boolean = false
+
+  constructor(
+    warningNode: JQuery<HTMLElement>,
+    audioFilterFreq: number,
+    audioFilterQ: number,
+    noSeek: boolean,
+  ) {
+    super(warningNode, audioFilterFreq, audioFilterQ, noSeek)
+  }
+
+  /**
+   * Mute or unmute the audio at the sound chip level.
+   */
+  override mute() {
+    this.muted = true
+    super.mute()
+  }
+
+  override unmute() {
+    this.muted = false
+    super.unmute()
+  }
+
+  /**
+   * Helper method
+   * @returns true if the audio engine is enabled for the webview
+   */
+  isEnabled(): boolean {
+    return this.audioContext && this.audioContext.state === 'running'
+  }
+}

--- a/src/scripts/emulator-toolbar.ts
+++ b/src/scripts/emulator-toolbar.ts
@@ -23,6 +23,14 @@ export class EmulatorToolBar {
     this.buttonSound.on('click', () => this.onSoundClick())
     this.buttonExpand.on('click', () => this.onExpandClick())
 
+    // use primary appearance for sound button if audio is disabled in webview
+    this.buttonSound.prop(
+      'appearance',
+      emulatorView.audioHandler.isEnabled() ? 'secondary' : 'primary',
+    )
+    // disable this button for now. We need RxJs to handle this properly
+    this.buttonSound.prop('disabled', true)
+
     // populate the model selector
     const modelSelector = (this.modelSelector = $('#model-selector'))
     const model = emulatorView.model

--- a/src/scripts/emulator-view.ts
+++ b/src/scripts/emulator-view.ts
@@ -4,7 +4,7 @@ import { Emulator, EmulatorCanvas } from './emulator'
 import { ClientCommand } from '../types/shared/messages'
 import { Model } from 'jsbeeb/models'
 import { notifyHost } from './vscode'
-import { AudioHandler } from 'jsbeeb/web/audio-handler'
+import { CustomAudioHandler } from './custom-audio-handler'
 
 const audioFilterFreq = 7000
 const audioFilterQ = 5
@@ -17,7 +17,7 @@ export class EmulatorView {
   canvas: EmulatorCanvas
   emulator: Emulator | undefined // Dont hold references to the emulator, it may be paused and destroyed
   model: Model | undefined
-  audioHandler: AudioHandler
+  audioHandler: CustomAudioHandler
 
   constructor() {
     const root = $('#emulator')
@@ -39,7 +39,7 @@ export class EmulatorView {
     screen.on('blur', () => this.emulator?.clearKeys())
 
     // create webview audio driver
-    this.audioHandler = new AudioHandler(
+    this.audioHandler = new CustomAudioHandler(
       $('#audio-warning'),
       audioFilterFreq,
       audioFilterQ,

--- a/src/scripts/emulator-view.ts
+++ b/src/scripts/emulator-view.ts
@@ -55,9 +55,9 @@ export class EmulatorView {
       // 	this.emulator.cpu.fdc.loadDisc(0, discImage);
       // }
       this.emulator.start()
-    } catch (e: any) {
+    } catch (e) {
       this.showTestCard(true)
-      notifyHost({ command: ClientCommand.Error, text: e.message })
+      notifyHost({ command: ClientCommand.Error, text: (e as Error).message })
     }
   }
 

--- a/src/scripts/emulator-view.ts
+++ b/src/scripts/emulator-view.ts
@@ -32,9 +32,11 @@ export class EmulatorView {
     this.canvas = bestCanvas(screen[0])
 
     // forward key events to emulator
-    screen.keyup((event: any) => this.emulator?.keyUp(event))
-    screen.keydown((event: any) => this.emulator?.keyDown(event))
-    screen.blur(() => this.emulator?.clearKeys())
+    screen.on('keyup', (event: JQuery.Event) => this.emulator?.onKeyUp(event))
+    screen.on('keydown', (event: JQuery.Event) =>
+      this.emulator?.onKeyDown(event),
+    )
+    screen.on('blur', () => this.emulator?.clearKeys())
 
     // create webview audio driver
     this.audioHandler = new AudioHandler(

--- a/src/scripts/emulator.ts
+++ b/src/scripts/emulator.ts
@@ -10,7 +10,7 @@ import { Model } from 'jsbeeb/models'
 import { BaseDisc, emptySsd } from 'jsbeeb/fdc'
 import { notifyHost } from './vscode'
 import { ClientCommand } from '../types/shared/messages'
-import { AudioHandler } from 'jsbeeb/web/audio-handler'
+import { CustomAudioHandler } from './custom-audio-handler'
 
 const ClocksPerSecond = (2 * 1000 * 1000) | 0
 const BotStartCycles = 725000 // bbcmicrobot start time
@@ -55,7 +55,7 @@ export class Emulator {
   constructor(
     public model: Model,
     public canvas: EmulatorCanvas,
-    public audioHandler: AudioHandler,
+    public audioHandler: CustomAudioHandler,
   ) {
     this.frames = 0
     this.frameSkip = 0

--- a/src/scripts/emulator.ts
+++ b/src/scripts/emulator.ts
@@ -125,11 +125,7 @@ export class Emulator {
   }
 
   async initialise() {
-    await Promise.all([
-      this.cpu.initialise(),
-      this.audioHandler.initialise(),
-      // this.ddNoise.initialise()
-    ])
+    await this.cpu.initialise()
     this.ready = true
   }
 
@@ -276,10 +272,10 @@ export class Emulator {
     )
   }
 
-  keyDown(event: any) {
+  onKeyDown(event: any) {
     if (!this.running) return
 
-    const code = this.keyCode(event)
+    const code = this.onKeyCode(event)
     const processor = this.cpu
     if (code === utils.keyCodes.HOME && event.ctrlKey) {
       this.pause()
@@ -296,9 +292,9 @@ export class Emulator {
     if (processor && processor.sysvia) processor.sysvia.clearKeys()
   }
 
-  keyUp(event: any) {
+  onKeyUp(event: any) {
     // Always let the key ups come through.
-    const code = this.keyCode(event)
+    const code = this.onKeyCode(event)
     const processor = this.cpu
     if (processor && processor.sysvia) processor.sysvia.keyUp(code)
     if (!this.running) return
@@ -308,7 +304,7 @@ export class Emulator {
     event.preventDefault()
   }
 
-  keyCode(event: any) {
+  onKeyCode(event: any) {
     const ret = event.which || event.charCode || event.keyCode
     const keyCodes = utils.keyCodes
     switch (event.location) {

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -22,6 +22,7 @@ async function initialise() {
 
   // create the emulator view container
   emulatorView = new EmulatorView()
+  await emulatorView.initialise()
 
   // boot the emulator
   await emulatorView.boot(defaultModel)

--- a/src/types/jsbeeb/models.d.ts
+++ b/src/types/jsbeeb/models.d.ts
@@ -37,6 +37,8 @@ declare module 'jsbeeb/models' {
     swram: SWRAM
     isTest: boolean
     tube: any
+    hasMusic5000: boolean
+
     constructor(
       name: string,
       synonyms: string[],

--- a/src/types/jsbeeb/web/audio-handler.d.ts
+++ b/src/types/jsbeeb/web/audio-handler.d.ts
@@ -1,0 +1,20 @@
+declare module 'jsbeeb/web/audio-handler' {
+  export class AudioHandler {
+    soundChip: any
+    ddNoise: any
+    music5000: any
+
+    constructor(
+      warningNode: JQuery<HTMLElement>,
+      audioFilterFreq: number,
+      audioFilterQ: number,
+      noSeek: boolean,
+    )
+
+    async tryResume(): Promise<void>
+    checkStatus(): void
+    async initialise()
+    mute(): void
+    unmute(): void
+  }
+}

--- a/src/types/jsbeeb/web/audio-handler.d.ts
+++ b/src/types/jsbeeb/web/audio-handler.d.ts
@@ -1,8 +1,12 @@
 declare module 'jsbeeb/web/audio-handler' {
+  import type { DdNoise, FakeDdNoise } from 'jsbeeb/ddnoise'
+  import type { FakeSoundChip, SoundChip } from 'jsbeeb/soundchip'
   export class AudioHandler {
-    soundChip: any
-    ddNoise: any
+    soundChip: SoundChip | FakeSoundChip
+    ddNoise: DdNoise | FakeDdNoise
     music5000: any
+
+    audioContext: AudioContext | webkitAudioContext | null
 
     constructor(
       warningNode: JQuery<HTMLElement>,


### PR DESCRIPTION
Borrowed `AudioHandler` from JSBeeb to create the webview audio context.

* Updated interfaces to receive this object
* Added a `CustomAudioHandler` implementation to extend the base class a bit
* Added a button that shows below the emulator view when audio context is suspended (since it requires user interaction to work)
* Emulator sound seems to work
* Fixed the disc drive noise media files being loaded

![image](https://github.com/simondotm/beeb-vsc/assets/7404321/276febab-7c33-4f8c-be5f-56d4daca2c5a)

