### PR TITLE
fix(emulator): Fix mute button state when enabling web audio

### DIFF
--- a/src/client/panels/emulator-panel.ts
+++ b/src/client/panels/emulator-panel.ts
@@ -223,7 +223,7 @@ export class EmulatorPanel {
 		</vscode-dropdown>
 
 		<vscode-button id="toolbar-sound" appearance="secondary">
-			<span class="codicon codicon-mute"></span>
+			<span class="codicon codicon-unmute"></span>
 		</vscode-button>
 
 		<vscode-button id="toolbar-expand" appearance="secondary">

--- a/src/scripts/custom-audio-handler.ts
+++ b/src/scripts/custom-audio-handler.ts
@@ -5,7 +5,7 @@ import { BehaviorSubject } from 'rxjs'
  * CustomAudioHandler extends AudioHandler to add a couple of additional interfaces.
  */
 export class CustomAudioHandler extends AudioHandler {
-  muted$ = new BehaviorSubject<boolean>(false)
+  muted$ = new BehaviorSubject<boolean>(true)
   enabled$ = new BehaviorSubject<boolean>(false)
 
   constructor(
@@ -43,6 +43,7 @@ export class CustomAudioHandler extends AudioHandler {
   private updateState() {
     const enabled = this.isEnabled()
     this.enabled$.next(enabled)
+    this.muted$.next(!enabled)
   }
 
   /**


### PR DESCRIPTION
Now correctly updates state of the audio button if web audio not enabled.