### PR TITLE
feat: Multiple target file handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Select the one that you wish to assemble with `BeebAsm`, and a new build target 
 
 ![Screenshot](./docs/images/targetcreated.png?raw=true)
 
-A `tasks.json` file will be created in a `.vscode` folder in your workspace containing the required tasks to build or run your targets.
+A `tasks.json` file will be created in a `.vscode` folder in your workspace containing the required tasks to build or run your targets. A `settings.json` file will also be created in the same location and is used for identifying the target source file(s) so we can parse the files in a suitable order even when viewing a different source file.
 
 ![Screenshot](./docs/images/tasksjson.png?raw=true)
 
@@ -131,6 +131,21 @@ The BeebVSC extension is careful to preserve the contents of the `tasks.json` fi
 The only property that is managed by the extension is `Group -> Kind`, so this is subject to modification.
 Note also that the commandline argument for the test task is managed by the extension, and updates whenever a new build target is selected.
 
+## Directly managing target source files
+If you don't want to use BeebVSC's functionality to add build targets, some functionality will be limited because the extension will not know what order INCLUDE files are processed. In this case, it is necessary to add the target file(s) to the `settings.json` file. For example, if the targets `build.asm` and `loader.asm` are run through BeebAsm then the settings file would look like: 
+```json
+{
+    "beebvsc": {
+        "sourceFile": [
+            "/Users/Games/Test/build.asm",
+            "/Users/Games/Test/loader.asm"
+        ],
+        "targetName": "main.ssd"
+    }
+}
+```
+The easiest way to set this up is adding the build targets in a normal way and they removing the `tasks.json` entries if those are not wanted.
+
 ## Command Line format
 Due to constraints in the way that Visual Studio Code handles tasks, BeebVSC tasks must be executed as single arguments to a shell such as `"cmd.exe"`.
 
@@ -139,6 +154,8 @@ The installation is for Windows by default, but its quite feasible to get it wor
 
 # Release notes
 
+- **0.1.2** - Tweaks to completions
+- **0.1.1** - Substantial internal refactoring and minor bug fixes
 - **0.1.0** - Move to LSP client/server structure, add hovers, completions, diagnostics and reference finding
 - **0.0.6** - Added full build environment support via JS script to extension
 - **0.0.5** - Test version

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -32,7 +32,7 @@ let client: LanguageClient
 
 interface BeebVSCSettings {
   beebvsc: {
-    sourceFile: string
+    sourceFile: string | string[]
     targetName: string
   }
 }
@@ -285,7 +285,7 @@ function CreateNewLocalSettingsJson(sourceFile: string, targetName: string) {
 
   const settingsObject: BeebVSCSettings = {
     beebvsc: {
-      sourceFile: sourcePath,
+      sourceFile: [sourcePath],
       targetName: targetName,
     },
   }
@@ -315,7 +315,7 @@ function setCurrentTarget(
             // no target file specified, so use the default target file
             targetFile = getTargetName(
               workspace.getConfiguration('beebvsc').get<string>('sourceFile') ??
-                'main.asm',
+              'main.asm',
             )
           }
         }
@@ -540,8 +540,20 @@ function SaveJSONFiles(
     }
     // now add the new settings
     console.log('Setting beebvsc object to settings.json')
+    const currentSourceFile = settingsObject.beebvsc?.sourceFile
+    let newSourceFile: string[] = []
+    if (typeof currentSourceFile === 'string') {
+      newSourceFile.push(currentSourceFile)
+    } else if (Array.isArray(currentSourceFile)) {
+      newSourceFile = currentSourceFile ?? []
+    } else {
+      newSourceFile = []
+    }
+    if (!newSourceFile.includes(path.join(rootPath, selection))) {
+      newSourceFile.push(path.join(rootPath, selection))
+    }
     settingsObject.beebvsc = {
-      sourceFile: path.join(rootPath, selection),
+      sourceFile: newSourceFile,
       targetName: targetDiskImage,
     }
 

--- a/src/server/beebasm-ts/sourcefile.ts
+++ b/src/server/beebasm-ts/sourcefile.ts
@@ -1,28 +1,29 @@
 /*************************************************************************************************/
 /**
-	Derived from sourcefile.cpp/h
+  Derived from sourcefile.cpp/h
 
-	Assembles a file
+  Assembles a file
 
 
-	Copyright (C) Rich Talbot-Watkins 2007 - 2012
+  Copyright (C) Rich Talbot-Watkins 2007 - 2012
 
-	This file is part of BeebAsm.
+  This file is part of BeebAsm.
 
-	BeebAsm is free software: you can redistribute it and/or modify it under the terms of the GNU
-	General Public License as published by the Free Software Foundation, either version 3 of the
-	License, or (at your option) any later version.
+  BeebAsm is free software: you can redistribute it and/or modify it under the terms of the GNU
+  General Public License as published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
 
-	BeebAsm is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
-	even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+  BeebAsm is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+  even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License along with BeebAsm, as
-	COPYING.txt.  If not, see <http://www.gnu.org/licenses/>.
+  You should have received a copy of the GNU General Public License along with BeebAsm, as
+  COPYING.txt.  If not, see <http://www.gnu.org/licenses/>.
 */
 /*************************************************************************************************/
 
 import { AST } from '../ast'
+import { FileHandler } from '../filehandler'
 import { SourceCode } from './sourcecode'
 import { Diagnostic, DocumentLink, URI } from 'vscode-languageserver'
 
@@ -36,7 +37,12 @@ export class SourceFile extends SourceCode {
     links: Map<string, DocumentLink[]>,
   ) {
     super(contents, 0, parent, diagnostics, uri, trees, links)
-    // console.log(`SourceFile constructor called for ${uri}`);
+    // set self-reference in source to parent map if this is a root file
+    if (parent === null) {
+      FileHandler.Instance.SetTargetFileName(uri, uri)
+    } else {
+      FileHandler.Instance.SetTargetFileName(uri, parent.GetURI())
+    }
   }
 
   GetLine(lineNumber: number): string {

--- a/src/server/beebasm-ts/symboltable.ts
+++ b/src/server/beebasm-ts/symboltable.ts
@@ -1,22 +1,22 @@
 /*************************************************************************************************/
 /**
-	Derived from symboltable.cpp/h
+  Derived from symboltable.cpp/h
 
 
-	Copyright (C) Rich Talbot-Watkins 2007 - 2012
+  Copyright (C) Rich Talbot-Watkins 2007 - 2012
 
-	This file is part of BeebAsm.
+  This file is part of BeebAsm.
 
-	BeebAsm is free software: you can redistribute it and/or modify it under the terms of the GNU
-	General Public License as published by the Free Software Foundation, either version 3 of the
-	License, or (at your option) any later version.
+  BeebAsm is free software: you can redistribute it and/or modify it under the terms of the GNU
+  General Public License as published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
 
-	BeebAsm is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
-	even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+  BeebAsm is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+  even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License along with BeebAsm, as
-	COPYING.txt.  If not, see <http://www.gnu.org/licenses/>.
+  You should have received a copy of the GNU General Public License along with BeebAsm, as
+  COPYING.txt.  If not, see <http://www.gnu.org/licenses/>.
 */
 /*************************************************************************************************/
 
@@ -178,6 +178,7 @@ export class SymbolTable {
   Reset(): void {
     this._map.clear()
     this._labelScopes = 0
+    this._labelList = []
     this._scopeDetails = []
     this._references.clear()
     this.AddSymbol('PI', Math.PI, noLocation)
@@ -242,6 +243,8 @@ export class SymbolTable {
   }
 
   AddLabel(symbol: string): void {
+    // Note: this data is not used (beebasm uses it for dumping label list to file)
+    // Keeping around for now in case it's useful in debugging
     if (GlobalData.Instance.IsSecondPass()) {
       const addr = ObjectCode.Instance.GetPC()
       const identifier =
@@ -257,7 +260,6 @@ export class SymbolTable {
       }
       this._labelList.push(this._lastLabel)
     }
-    // TODO - check if can add symbol on second pass, currently getting deleted after first pass and not re-added
   }
 
   PushBrace(uri: string, startLine: number, forID: number): void {

--- a/src/server/completions.ts
+++ b/src/server/completions.ts
@@ -30,7 +30,7 @@ const commandCompletions: CompletionItem[] = beebasmCommands.map((item) => ({
   label: item.command,
   kind: CompletionItemKind.Method,
   insertTextFormat: InsertTextFormat.Snippet,
-  insertText: `${item.label} $0`,
+  insertText: `${item.command} $0`,
   command: triggerParameterHints,
   detail: 'command',
   documentation: item.documentation,

--- a/src/server/filehandler.ts
+++ b/src/server/filehandler.ts
@@ -11,6 +11,7 @@ export class FileHandler {
   private static _instance: FileHandler
   private _textDocuments: Map<string, { contents: string; modified: Date }> =
     new Map<string, { contents: string; modified: Date }>()
+  private includedToParentMap = new Map<string, string>()
   public documents: TextDocuments<TextDocument> = new TextDocuments(
     TextDocument,
   )
@@ -22,6 +23,27 @@ export class FileHandler {
   public static get Instance() {
     // Do you need arguments? Make it a regular static method instead.
     return this._instance || (this._instance = new this())
+  }
+
+  public GetTargetFileName(fileName: string): string | undefined {
+    // Recursively get the parent file name until
+    // the parent file name is the same as the file name
+    let targetFileName = this.includedToParentMap.get(fileName)
+    if (targetFileName === undefined) {
+      return undefined
+    }
+    while (targetFileName !== fileName) {
+      fileName = targetFileName
+      targetFileName = this.includedToParentMap.get(fileName)
+      if (targetFileName === undefined) {
+        return undefined // shouldn't end up here
+      }
+    }
+    return targetFileName
+  }
+
+  public SetTargetFileName(fileName: string, targetFileName: string): void {
+    this.includedToParentMap.set(fileName, targetFileName)
   }
 
   public Clear(): void {

--- a/src/server/hoverprovider.ts
+++ b/src/server/hoverprovider.ts
@@ -48,7 +48,7 @@ export class HoverProvider {
           // try to find in list of commands beebasmCommands
           // iterate through beebasmCommands looking for a match
           for (const cmd of beebasmCommands) {
-            if (cmd.label === command) {
+            if (cmd.command === command) {
               const mdText: MarkupContent = {
                 kind: 'markdown',
                 value: `## ${cmd.label}
@@ -133,12 +133,12 @@ ${this.getFlagsTable(info.flags)}`
    */
   private getFlagsTable(flags: string): string {
     /* Flag meanings:
-		-  Flag unaffected
-		*  Flag affected
-		0  Flag reset
-		1  Flag set
-		?  Unknown
-		Order: NV_BDIZC */
+    -  Flag unaffected
+    *  Flag affected
+    0  Flag reset
+    1  Flag set
+    ?  Unknown
+    Order: NV_BDIZC */
 
     if (flags.length === 0) {
       flags = '--------'


### PR DESCRIPTION
Primarily adds the ability to have multiple target files stored in the settings.json file and be used to correctly parse more complex projects where included files may belong to different compile targets. As the target files are parsed, each included file gets a reference to its parent, so we can reuse that in the future. 

