### PR TITLE
feat: Set input focus when emulator view is focused

### DIFF
--- a/src/scripts/emulator-infobar.ts
+++ b/src/scripts/emulator-infobar.ts
@@ -52,7 +52,6 @@ export class EmulatorInfoBar {
   }
 
   private updateScreenMode(displayInfo: DisplayModeInfo | null) {
-    console.log('updateScreenMode', displayInfo)
     this.mode.html(displayInfo ? `Mode ${displayInfo.mode}` : EMPTY_CHAR)
   }
 

--- a/src/scripts/emulator-toolbar.ts
+++ b/src/scripts/emulator-toolbar.ts
@@ -79,7 +79,7 @@ export class EmulatorToolBar {
     this.emulatorView.boot(model).then(() => {
       this.updateEmulatorStatus()
     })
-    this.emulatorView.focus()
+    this.emulatorView.focusInput()
   }
 
   private updateEmulatorStatus() {
@@ -101,14 +101,14 @@ export class EmulatorToolBar {
       emulator.pause()
     } else {
       emulator?.start()
-      this.emulatorView.focus()
+      this.emulatorView.focusInput()
     }
     this.updateEmulatorStatus()
   }
   private onRestartClick() {
     if (this.buttonRestart) {
-      this.emulatorView.reset(true)
-      this.emulatorView.focus()
+      this.emulatorView.resetCpu(true)
+      this.emulatorView.focusInput()
     }
   }
   private onSoundClick() {
@@ -119,7 +119,7 @@ export class EmulatorToolBar {
   private onExpandClick() {
     if (this.buttonExpand) {
       this.emulatorView.toggleFullscreen()
-      this.emulatorView.focus()
+      this.emulatorView.focusInput()
     }
   }
 }

--- a/src/scripts/emulator-view.ts
+++ b/src/scripts/emulator-view.ts
@@ -157,6 +157,10 @@ export class EmulatorView {
     }
   }
 
+  /**
+   * Soft or hard reset the CPU and remount the current disc image (if any)
+   * @param hard - true for a hard reset, false for a soft reset
+   */
   async resetCpu(hard: boolean = true) {
     if (this.emulator) {
       this.emulator.cpu.reset(hard)

--- a/src/scripts/emulator-view.ts
+++ b/src/scripts/emulator-view.ts
@@ -133,7 +133,10 @@ export class EmulatorView {
     }
   }
 
-  focus() {
+  /**
+   * Capture input to the emulator
+   */
+  focusInput() {
     this.screen.focus()
   }
 
@@ -154,7 +157,7 @@ export class EmulatorView {
     }
   }
 
-  async reset(hard: boolean = true) {
+  async resetCpu(hard: boolean = true) {
     if (this.emulator) {
       this.emulator.cpu.reset(hard)
       if (this.mountedDisc) {

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -44,7 +44,17 @@ window.addEventListener('load', (event) => {
   notifyHost({ command: ClientCommand.PageLoaded })
 })
 
-// Handle messages received from the host extension
+// Set up event handler to produce text for the window focus event
+window.addEventListener(
+  'focus',
+  (_event) => {
+    console.log('window focused')
+    emulatorView.focusInput()
+  },
+  false,
+)
+
+// Handle messages received from the host extensiond
 window.addEventListener('message', (event) => {
   const message = event.data as HostMessage // The JSON data our extension sent
   console.log('message received')
@@ -55,6 +65,11 @@ window.addEventListener('message', (event) => {
       if (message.url) {
         emulatorView.mountDisc(message.url, true)
       }
+      break
+    case HostCommand.ViewFocus:
+      // if (message.isViewFocused) {
+      //   emulatorView.focus()
+      // }
       break
   }
 })

--- a/src/types/shared/messages.ts
+++ b/src/types/shared/messages.ts
@@ -9,17 +9,22 @@ export const enum ClientCommand {
   Error = 'error',
 }
 
-// Message from host to client
-export const enum HostCommand {
-  LoadDisc = 'loadDisc',
-}
-
 export interface ClientMessage extends MessageBase {
   command: ClientCommand
   text?: string
 }
 
+// Message from host to client
+export const enum HostCommand {
+  LoadDisc = 'loadDisc',
+  ViewFocus = 'viewFocus',
+}
+
 export interface HostMessage extends MessageBase {
   command: HostCommand
   url?: string
+  focus?: {
+    active: boolean
+    visible: boolean
+  }
 }


### PR DESCRIPTION
The emulator now gets input focus when the webview panel gets focus.
It also gets input focus after using toolbar buttons which seems the most intuitive solution.

Client now also gets notified of panel `visible` and `active` state changes, but doesn't yet need to run any logic on these.

Decided not to reload image when focus is acquired, could be unexpected if already running some code. Instead, the reset button will reload the disc image, and user can immediately shift+break etc. if they like since emulator will now have input focus.


