### PR TITLE
feat(emulator): Disc selection toolbar

### DIFF
--- a/src/client/panels/emulator-panel.ts
+++ b/src/client/panels/emulator-panel.ts
@@ -84,7 +84,7 @@ export class EmulatorPanel {
       this.watcher.onDidChange((uri) => {
         this.notifyClient({
           command: HostCommand.DiscImageChanges,
-          discImageChanges: { changed: [this.discImageFileFromUri(uri)] },
+          changed: [this.discImageFileFromUri(uri)],
         })
       })
       // update client with all disc image files in the workspace when added
@@ -92,7 +92,7 @@ export class EmulatorPanel {
         this.sendDiscImages(workspaceRoot)
         this.notifyClient({
           command: HostCommand.DiscImageChanges,
-          discImageChanges: { created: [this.discImageFileFromUri(uri)] },
+          created: [this.discImageFileFromUri(uri)],
         })
       })
       // update client with all disc image files in the workspace when deleted
@@ -100,7 +100,7 @@ export class EmulatorPanel {
         this.sendDiscImages(workspaceRoot)
         this.notifyClient({
           command: HostCommand.DiscImageChanges,
-          discImageChanges: { deleted: [this.discImageFileFromUri(uri)] },
+          deleted: [this.discImageFileFromUri(uri)],
         })
       })
     }
@@ -150,12 +150,14 @@ export class EmulatorPanel {
         switch (command) {
           case ClientCommand.PageLoaded:
             vscode.window.showInformationMessage('loaded page')
-            // start watching for disc images
-            this.startWatcher()
             return
           case ClientCommand.EmulatorReady:
+            // when the client side emulator signals it is ready
+            // we can send it the default disc image file to load (if any)
             console.log('EmulatorReady')
             this.loadDisc()
+            // start watching for disc image files in the workspace
+            this.startWatcher()
             return
           case ClientCommand.Error:
             vscode.window.showInformationMessage(
@@ -223,10 +225,9 @@ export class EmulatorPanel {
       EmulatorPanel.instance = new EmulatorPanel(context)
     }
 
-    // always update the webview content when creating or revealing
-    // todo: load disc using messages rather than html changes. this way the script can reset the emulator, or optionally auto-boot
+    // notify the client of a disc selection if emulator was
+    // launched via a file context menu
     if (contextSelection) {
-      // TODO: pass message to webview to update disc file
       EmulatorPanel.instance.setDiscFileUrl(contextSelection)
     }
   }
@@ -296,8 +297,10 @@ export class EmulatorPanel {
 
         <vscode-dropdown id="disc-selector" class="fixed-width-selector">
           <span slot="indicator" class="codicon codicon-save"></span>
-          <vscode-option>Empty</vscode-option>
-          <vscode-option>image.dsd</vscode-option>			
+          <vscode-option >1</vscode-option>
+          <vscode-option >2</vscode-option>
+          <vscode-option >3</vscode-option>
+          <vscode-option selected>4</vscode-option>
         </vscode-dropdown>
 
         <vscode-button id="toolbar-sound" appearance="secondary">

--- a/src/client/panels/emulator-panel.ts
+++ b/src/client/panels/emulator-panel.ts
@@ -181,7 +181,7 @@ export class EmulatorPanel {
   loadDisc() {
     this.notifyClient({
       command: HostCommand.LoadDisc,
-      url: this.discImageFile,
+      discImageFile: this.discImageFile,
     })
   }
 

--- a/src/client/panels/emulator-panel.ts
+++ b/src/client/panels/emulator-panel.ts
@@ -221,14 +221,21 @@ export class EmulatorPanel {
   ) {
     if (EmulatorPanel.instance) {
       EmulatorPanel.instance.panel.reveal(vscode.ViewColumn.One)
+
+      // notify the client of a disc selection if emulator was
+      // launched via a file context menu
+      if (contextSelection) {
+        EmulatorPanel.instance.setDiscFileUrl(contextSelection)
+        EmulatorPanel.instance.loadDisc()
+      }
     } else {
       EmulatorPanel.instance = new EmulatorPanel(context)
-    }
 
-    // notify the client of a disc selection if emulator was
-    // launched via a file context menu
-    if (contextSelection) {
-      EmulatorPanel.instance.setDiscFileUrl(contextSelection)
+      // notify the client of a disc selection if emulator was
+      // launched via a file context menu
+      if (contextSelection) {
+        EmulatorPanel.instance.setDiscFileUrl(contextSelection)
+      }
     }
   }
 

--- a/src/client/panels/emulator-panel.ts
+++ b/src/client/panels/emulator-panel.ts
@@ -304,10 +304,6 @@ export class EmulatorPanel {
 
         <vscode-dropdown id="disc-selector" class="fixed-width-selector">
           <span slot="indicator" class="codicon codicon-save"></span>
-          <vscode-option >1</vscode-option>
-          <vscode-option >2</vscode-option>
-          <vscode-option >3</vscode-option>
-          <vscode-option selected>4</vscode-option>
         </vscode-dropdown>
 
         <vscode-button id="toolbar-sound" appearance="secondary">

--- a/src/client/panels/emulator-panel.ts
+++ b/src/client/panels/emulator-panel.ts
@@ -156,7 +156,7 @@ export class EmulatorPanel {
             // when the client side emulator signals it is ready
             // we can send it the default disc image file to load (if any)
             console.log('EmulatorReady')
-            this.loadDisc()
+            this.loadDisc({ shouldAutoBoot: true })
             // start watching for disc image files in the workspace
             this.startWatcher()
             return
@@ -171,13 +171,6 @@ export class EmulatorPanel {
       this.disposables,
     )
   }
-
-  // setDiscFileUrl(discFile?: vscode.Uri) {
-  //   this.discImageFile = discFile
-  //     ? this.discImageFileFromUri(discFile)
-  //     : NO_DISC
-  //   console.log('setDiscFileUrl=' + this.discImageFile)
-  // }
 
   /**
    * Instruct client to load the given disc image file

--- a/src/client/panels/emulator-panel.ts
+++ b/src/client/panels/emulator-panel.ts
@@ -113,11 +113,9 @@ export class EmulatorPanel {
    */
   private sendDiscImages(_workspaceRoot: vscode.WorkspaceFolder) {
     vscode.workspace.findFiles(glob).then((uris) => {
-      console.log(`found uris:`, uris)
       const allFiles: DiscImageFile[] = uris.map((uri) => {
         return this.discImageFileFromUri(uri)
       })
-      console.log(`found files:`, allFiles)
       this.notifyClient({
         command: HostCommand.DiscImages,
         discImages: allFiles,
@@ -146,11 +144,9 @@ export class EmulatorPanel {
     webview.onDidReceiveMessage(
       (message: ClientMessage) => {
         const command = message.command
-        // const text = message.text;
-
         switch (command) {
           case ClientCommand.PageLoaded:
-            vscode.window.showInformationMessage('loaded page')
+            vscode.window.showInformationMessage('BeebVSC: Emulator started')
             return
           case ClientCommand.EmulatorReady:
             // when the client side emulator signals it is ready
@@ -160,9 +156,14 @@ export class EmulatorPanel {
             // start watching for disc image files in the workspace
             this.startWatcher()
             return
-          case ClientCommand.Error:
+          case ClientCommand.Info:
             vscode.window.showInformationMessage(
-              `${message.text ?? 'An error occurred'}`,
+              `BeebVSC: ${message.text ?? 'An error occurred'}`,
+            )
+            return
+          case ClientCommand.Error:
+            vscode.window.showErrorMessage(
+              `BeebVSC: ${message.text ?? 'An error occurred'}`,
             )
             return
         }

--- a/src/scripts/emulator-infobar.ts
+++ b/src/scripts/emulator-infobar.ts
@@ -42,10 +42,14 @@ export class EmulatorInfoBar {
     let html = EMPTY_CHAR
     if (emulator) {
       const totalSeconds = Math.floor(emulator.cpu.currentCycles / 2000000)
-      const seconds = totalSeconds % 60
-      const minutes = Math.floor(totalSeconds / 60)
-      const hours = Math.floor(minutes / 60)
-      const et = `${hours ? hours : ''}${hours ? 'h ' : ''}${minutes ? minutes : ''}${minutes ? 'm ' : ''}${seconds ? seconds : ''}${seconds ? 's' : ''}`
+      const seconds = Math.floor(totalSeconds) % 60
+      const minutes = Math.floor(totalSeconds / 60) % 60
+      const hours = Math.floor(minutes / 60) % 24
+      const days = Math.floor(hours / 24)
+      const showMinutes = minutes > 0 || hours > 0 || days > 0
+      const showHours = hours > 0 || days > 0
+      const showDays = days > 0
+      const et = `${showDays ? days + 'd ' : ''}${showHours ? hours + 'h ' : ''}${showMinutes ? minutes + 'm ' : ''}${seconds}s`
       html = `Runtime: ${et}`
     }
     this.runTime.html(html)

--- a/src/scripts/emulator-toolbar.ts
+++ b/src/scripts/emulator-toolbar.ts
@@ -158,7 +158,7 @@ export class EmulatorToolBar {
   }
   private async onRestartClick() {
     if (this.buttonRestart) {
-      await this.emulatorView.resetCpu(true)
+      await this.emulatorView.reboot(true)
       this.emulatorView.focusInput()
     }
   }

--- a/src/scripts/emulator-toolbar.ts
+++ b/src/scripts/emulator-toolbar.ts
@@ -100,7 +100,7 @@ export class EmulatorToolBar {
     const value = $(event.target).val() as string
     const [url, name] = value.split('|')
     if (url) {
-      await this.emulatorView.emulator?.loadDisc(
+      await this.emulatorView.loadDisc(
         {
           url,
           name,
@@ -108,7 +108,7 @@ export class EmulatorToolBar {
         true,
       )
     } else {
-      this.emulatorView.emulator?.ejectDisc()
+      this.emulatorView.ejectDisc()
     }
     this.emulatorView.focusInput()
   }
@@ -118,8 +118,7 @@ export class EmulatorToolBar {
     this.discSelector.find('vscode-option').remove().end()
     this.discSelector.val('')
     const options = [...discImages, NO_DISC]
-    const currentDiscName =
-      this.emulatorView.emulator?.discImageFile.name ?? NO_DISC.name
+    const currentDiscName = this.emulatorView.discImageFile.name ?? NO_DISC.name
     for (const discImage of options) {
       const selected = discImage.name === currentDiscName ? 'selected' : ''
       const option = $(`<vscode-option ${selected} />`)
@@ -154,7 +153,7 @@ export class EmulatorToolBar {
   }
   private async onRestartClick() {
     if (this.buttonRestart) {
-      await this.emulatorView.emulator?.resetCpu(true)
+      await this.emulatorView.resetCpu(true)
       this.emulatorView.focusInput()
     }
   }

--- a/src/scripts/emulator-toolbar.ts
+++ b/src/scripts/emulator-toolbar.ts
@@ -64,8 +64,16 @@ export class EmulatorToolBar {
     // populate the disc image selector
     this.discSelector = $('#disc-selector')
 
+    // this.discSelector.append($(`<vscode-option />`).val(`a`).text(`a`))
+    // this.discSelector.append($(`<vscode-option />`).val(`b`).text(`b`))
+    // this.discSelector.append($(`<vscode-option selected />`).val(`c`).text(`c`))
+    // this.discSelector.append($(`<vscode-option />`).val(`d`).text(`d`))
+
     this.emulatorView.discImages$.subscribe((discImages) => {
-      this.discSelector.empty()
+      // dont use empty, because we have a span child node for the icon
+      this.discSelector.find('vscode-option').remove().end()
+      // this.discSelector.empty()
+      this.discSelector.val('')
       const options = [...discImages, NO_DISC]
       const currentDiscName =
         this.emulatorView.emulator?.discImageFile.name ?? NO_DISC.name
@@ -73,20 +81,21 @@ export class EmulatorToolBar {
         const selected = discImage.name === currentDiscName ? 'selected' : ''
         const option = $(`<vscode-option ${selected} />`)
           .val(`${discImage.url}|${discImage.name}`)
-          .text(`${discImage.name} ${selected}`)
+          .text(`${discImage.name}`)
         this.discSelector.append(option)
       }
-
-      this.discSelector.append(
-        $('<span slot="indicator" class="codicon codicon-save"></span>;='),
-      )
-      this.discSelector.append($('<vscode-option />').val('A').text('A'))
-      this.discSelector.append($('<vscode-option />').val('B').text('B'))
-      this.discSelector.append(
-        $('<vscode-option />').val(NO_DISC.url).text(NO_DISC.name),
-      )
-      this.discSelector.append($('<vscode-option />').val('D').text('D'))
     })
+
+    //   this.discSelector.append(
+    //     $('<span slot="indicator" class="codicon codicon-save"></span>;='),
+    //   )
+    //   this.discSelector.append($('<vscode-option />').val('A').text('A'))
+    //   this.discSelector.append($('<vscode-option />').val('B').text('B'))
+    //   this.discSelector.append(
+    //     $('<vscode-option />').val(NO_DISC.url).text(NO_DISC.name),
+    //   )
+    //   this.discSelector.append($('<vscode-option />').val('D').text('D'))
+    // })
 
     // this.emulatorView.discImages$.subscribe((discImages) => {
     //   this.discSelector.find('vscode-option').remove().end() // empty()

--- a/src/scripts/emulator-toolbar.ts
+++ b/src/scripts/emulator-toolbar.ts
@@ -63,16 +63,9 @@ export class EmulatorToolBar {
 
     // populate the disc image selector
     this.discSelector = $('#disc-selector')
-
-    // this.discSelector.append($(`<vscode-option />`).val(`a`).text(`a`))
-    // this.discSelector.append($(`<vscode-option />`).val(`b`).text(`b`))
-    // this.discSelector.append($(`<vscode-option selected />`).val(`c`).text(`c`))
-    // this.discSelector.append($(`<vscode-option />`).val(`d`).text(`d`))
-
     this.emulatorView.discImages$.subscribe((discImages) => {
       // dont use empty, because we have a span child node for the icon
       this.discSelector.find('vscode-option').remove().end()
-      // this.discSelector.empty()
       this.discSelector.val('')
       const options = [...discImages, NO_DISC]
       const currentDiscName =
@@ -85,36 +78,6 @@ export class EmulatorToolBar {
         this.discSelector.append(option)
       }
     })
-
-    //   this.discSelector.append(
-    //     $('<span slot="indicator" class="codicon codicon-save"></span>;='),
-    //   )
-    //   this.discSelector.append($('<vscode-option />').val('A').text('A'))
-    //   this.discSelector.append($('<vscode-option />').val('B').text('B'))
-    //   this.discSelector.append(
-    //     $('<vscode-option />').val(NO_DISC.url).text(NO_DISC.name),
-    //   )
-    //   this.discSelector.append($('<vscode-option />').val('D').text('D'))
-    // })
-
-    // this.emulatorView.discImages$.subscribe((discImages) => {
-    //   this.discSelector.find('vscode-option').remove().end() // empty()
-    //   discImages.push(NO_DISC)
-    //   const selectedDisc = this.emulatorView.mountedDisc ?? NO_DISC
-    //   console.log(`selectedDisc: ${selectedDisc}`)
-    //   for (const discImage of discImages) {
-    //     console.log(`discImage: ${discImage.name}`)
-    //     const selected = discImage.name === selectedDisc.name ? 'selected' : ''
-    //     console.log(`selected: ${selected}`)
-    //     const option = $(`<vscode-option />`)
-    //       .val(discImage.url)
-    //       .text(discImage.name)
-    //     if (selected) {
-    //       option.attr('selected', 'selected')
-    //     }
-    //     this.discSelector.append(option)
-    //   }
-    // })
 
     this.discSelector.on('change', async (event: JQuery.ChangeEvent) =>
       this.onDiscChange(event),

--- a/src/scripts/emulator-toolbar.ts
+++ b/src/scripts/emulator-toolbar.ts
@@ -11,6 +11,7 @@ export class EmulatorToolBar {
   buttonExpand: JQuery<HTMLElement>
 
   modelSelector: JQuery<HTMLElement>
+  discSelector: JQuery<HTMLElement>
 
   constructor(public emulatorView: EmulatorView) {
     this.buttonControl = $('#toolbar-control')
@@ -59,6 +60,18 @@ export class EmulatorToolBar {
     this.modelSelector.on('change', (event: JQuery.ChangeEvent) =>
       this.onModelChange(event),
     )
+
+    // populate the disc image selector
+    this.discSelector = $('#disc-selector')
+    this.emulatorView.discImages$.subscribe((discImages) => {
+      this.discSelector.empty()
+      discImages.push({ uri: '', name: '-- no disk --' })
+      for (const discImage of discImages) {
+        this.discSelector.append(
+          $(`<vscode-option />`).val(discImage.uri).text(discImage.name),
+        )
+      }
+    })
 
     this.updateEmulatorStatus()
   }

--- a/src/scripts/emulator-toolbar.ts
+++ b/src/scripts/emulator-toolbar.ts
@@ -95,10 +95,10 @@ export class EmulatorToolBar {
     await this.emulatorView.boot(model)
     this.updateEmulatorStatus()
     this.emulatorView.focusInput()
-    notifyHost({
-      command: ClientCommand.Error,
-      text: `Selected model '${model.name}'`,
-    })
+    // notifyHost({
+    //   command: ClientCommand.Info,
+    //   text: `Selected model '${model.name}'`,
+    // })
   }
 
   private async onDiscChange(event: JQuery.ChangeEvent) {

--- a/src/scripts/emulator-toolbar.ts
+++ b/src/scripts/emulator-toolbar.ts
@@ -2,7 +2,7 @@ import $ from 'jquery'
 import { EmulatorView } from './emulator-view'
 import { allModels, findModel } from 'jsbeeb/models'
 import { notifyHost } from './vscode'
-import { ClientCommand } from '../types/shared/messages'
+import { ClientCommand, NO_DISC } from '../types/shared/messages'
 
 export class EmulatorToolBar {
   buttonControl: JQuery<HTMLElement>
@@ -65,10 +65,17 @@ export class EmulatorToolBar {
     this.discSelector = $('#disc-selector')
     this.emulatorView.discImages$.subscribe((discImages) => {
       this.discSelector.empty()
-      discImages.push({ uri: '', name: '-- no disk --' })
+      discImages.push(NO_DISC)
+      const selectedDisc = this.emulatorView.mountedDisc ?? NO_DISC
+      console.log(`selectedDisc: ${selectedDisc}`)
       for (const discImage of discImages) {
+        console.log(`discImage: ${discImage.name}`)
+        const selected = discImage.name === selectedDisc.name ? 'selected' : ''
+        console.log(`selected: ${selected}`)
         this.discSelector.append(
-          $(`<vscode-option />`).val(discImage.uri).text(discImage.name),
+          $(`<vscode-option ${selected} />`)
+            .val(discImage.uri)
+            .text(discImage.name),
         )
       }
     })

--- a/src/scripts/emulator-toolbar.ts
+++ b/src/scripts/emulator-toolbar.ts
@@ -105,7 +105,7 @@ export class EmulatorToolBar {
           url,
           name,
         },
-        true,
+        {},
       )
     } else {
       this.emulatorView.ejectDisc()

--- a/src/scripts/emulator-toolbar.ts
+++ b/src/scripts/emulator-toolbar.ts
@@ -74,7 +74,7 @@ export class EmulatorToolBar {
         console.log(`selected: ${selected}`)
         this.discSelector.append(
           $(`<vscode-option ${selected} />`)
-            .val(discImage.uri)
+            .val(discImage.url)
             .text(discImage.name),
         )
       }

--- a/src/scripts/emulator-toolbar.ts
+++ b/src/scripts/emulator-toolbar.ts
@@ -104,17 +104,13 @@ export class EmulatorToolBar {
   private async onDiscChange(event: JQuery.ChangeEvent) {
     const value = $(event.target).val() as string
     const [url, name] = value.split('|')
-    if (url) {
-      await this.emulatorView.mountDisc(
-        {
-          url,
-          name,
-        },
-        {},
-      )
-    } else {
-      this.emulatorView.unmountDisc()
-    }
+    await this.emulatorView.mountDisc(
+      {
+        url,
+        name,
+      },
+      {},
+    )
     this.emulatorView.focusInput()
   }
 

--- a/src/scripts/emulator-toolbar.ts
+++ b/src/scripts/emulator-toolbar.ts
@@ -67,6 +67,11 @@ export class EmulatorToolBar {
       this.onDiscImagesUpdate(discImages),
     )
 
+    // update the disc image selector when the current disc image changes
+    this.emulatorView.discImageFile$.subscribe((discImage) =>
+      this.onDiscImageUpdate(discImage),
+    )
+
     this.discSelector.on('change', async (event: JQuery.ChangeEvent) =>
       this.onDiscChange(event),
     )
@@ -100,7 +105,7 @@ export class EmulatorToolBar {
     const value = $(event.target).val() as string
     const [url, name] = value.split('|')
     if (url) {
-      await this.emulatorView.loadDisc(
+      await this.emulatorView.mountDisc(
         {
           url,
           name,
@@ -108,7 +113,7 @@ export class EmulatorToolBar {
         {},
       )
     } else {
-      this.emulatorView.ejectDisc()
+      this.emulatorView.unmountDisc()
     }
     this.emulatorView.focusInput()
   }
@@ -126,6 +131,10 @@ export class EmulatorToolBar {
         .text(`${discImage.name}`)
       this.discSelector.append(option)
     }
+  }
+
+  private onDiscImageUpdate(discImage: DiscImageFile) {
+    this.discSelector.val(`${discImage.url}|${discImage.name}`)
   }
 
   private updateEmulatorStatus() {

--- a/src/scripts/emulator-toolbar.ts
+++ b/src/scripts/emulator-toolbar.ts
@@ -68,7 +68,7 @@ export class EmulatorToolBar {
       this.discSelector.empty()
       const options = [...discImages, NO_DISC]
       const currentDiscName =
-        this.emulatorView.mountedDisc?.name ?? NO_DISC.name
+        this.emulatorView.emulator?.discImageFile.name ?? NO_DISC.name
       for (const discImage of options) {
         const selected = discImage.name === currentDiscName ? 'selected' : ''
         const option = $(`<vscode-option ${selected} />`)
@@ -141,7 +141,7 @@ export class EmulatorToolBar {
     const value = $(event.target).val() as string
     const [url, name] = value.split('|')
     if (url) {
-      await this.emulatorView.mountDisc(
+      await this.emulatorView.emulator?.loadDisc(
         {
           url,
           name,
@@ -149,7 +149,7 @@ export class EmulatorToolBar {
         true,
       )
     } else {
-      this.emulatorView.unmountDisc()
+      this.emulatorView.emulator?.ejectDisc()
     }
     this.emulatorView.focusInput()
   }
@@ -179,7 +179,7 @@ export class EmulatorToolBar {
   }
   private onRestartClick() {
     if (this.buttonRestart) {
-      this.emulatorView.resetCpu(true)
+      this.emulatorView.emulator?.resetCpu(true)
       this.emulatorView.focusInput()
     }
   }

--- a/src/scripts/emulator-view.ts
+++ b/src/scripts/emulator-view.ts
@@ -152,8 +152,12 @@ export class EmulatorView {
   async mountDisc(discImageFile: DiscImageFile, autoBoot: boolean = false) {
     console.log(`mountDisc=${discImageFile}`)
     this.mountedDisc = discImageFile
-    if (this.emulator) {
+    if (this.emulator && discImageFile.url) {
       await this.emulator.loadDisc(discImageFile.url)
+      notifyHost({
+        command: ClientCommand.Error,
+        text: `Mounted disc '${discImageFile.name}'`,
+      })
       if (autoBoot) {
         this.emulator.holdShift()
       }
@@ -164,6 +168,10 @@ export class EmulatorView {
     if (this.emulator) {
       this.emulator.ejectDisc()
       this.mountedDisc = NO_DISC
+      notifyHost({
+        command: ClientCommand.Error,
+        text: `Disc ejected`,
+      })
     }
   }
 

--- a/src/scripts/emulator-view.ts
+++ b/src/scripts/emulator-view.ts
@@ -131,9 +131,9 @@ export class EmulatorView {
     this.showTestCard(this.emulator === undefined)
   }
 
-  private onEmulatorUpdate(_emulator: Emulator) {
+  private onEmulatorUpdate(emulator: Emulator) {
     // update display mode
-    const mode = this.emulator?.cpu.readmem(0x0355) ?? 255
+    const mode = emulator.cpu.readmem(0x0355) ?? 255
     this._displayMode$.next(getDisplayModeInfo(mode))
   }
 

--- a/src/scripts/emulator-view.ts
+++ b/src/scripts/emulator-view.ts
@@ -169,7 +169,7 @@ export class EmulatorView {
     return true
   }
 
-  async resetCpu(hard: boolean = false) {
+  async reboot(hard: boolean = false) {
     this.emulator?.resetCpu(hard)
     await this.mountDisc(this.discImageFile)
   }

--- a/src/scripts/emulator-view.ts
+++ b/src/scripts/emulator-view.ts
@@ -6,7 +6,12 @@ import { CustomAudioHandler } from './custom-audio-handler'
 import { BehaviorSubject, Observable, distinctUntilChanged } from 'rxjs'
 import { DisplayMode, getDisplayModeInfo } from './display-modes'
 import { notifyHost } from './vscode'
-import { ClientCommand, DiscImageFile, NO_DISC } from '../types/shared/messages'
+import {
+  ClientCommand,
+  DiscImageFile,
+  DiscImageOptions,
+  NO_DISC,
+} from '../types/shared/messages'
 
 const audioFilterFreq = 7000
 const audioFilterQ = 5
@@ -22,8 +27,10 @@ export class EmulatorView {
   model: Model | undefined
   emulator: Emulator | undefined // Dont hold references to the emulator, it may be paused and destroyed
 
+  // currently selected disc image
   discImageFile: DiscImageFile = NO_DISC
 
+  // disc images in the current workspace
   private _discImages$ = new BehaviorSubject<DiscImageFile[]>([])
   get discImages$(): Observable<DiscImageFile[]> {
     return this._discImages$
@@ -149,13 +156,16 @@ export class EmulatorView {
 
   async loadDisc(
     discImageFile: DiscImageFile,
-    autoBoot: boolean = false,
+    discImageOptions?: DiscImageOptions,
   ): Promise<boolean> {
     if (!this.emulator) {
       return false
     }
     if (discImageFile.url) {
-      const loaded = await this.emulator.loadDisc(discImageFile, autoBoot)
+      const loaded = await this.emulator.loadDisc(
+        discImageFile,
+        discImageOptions,
+      )
       if (loaded) {
         this.discImageFile = discImageFile
         return true
@@ -180,10 +190,10 @@ export class EmulatorView {
     await this.loadDisc(this.discImageFile)
   }
 
-  async resetCpu(hard: boolean = true) {
+  async resetCpu(hard: boolean = false) {
     if (this.emulator) {
       this.emulator.resetCpu(hard)
-      await this.reloadDisc()
+      // await this.reloadDisc()
     }
   }
 }

--- a/src/scripts/emulator-view.ts
+++ b/src/scripts/emulator-view.ts
@@ -6,7 +6,7 @@ import { CustomAudioHandler } from './custom-audio-handler'
 import { BehaviorSubject, Observable, distinctUntilChanged } from 'rxjs'
 import { DisplayMode, getDisplayModeInfo } from './display-modes'
 import { notifyHost } from './vscode'
-import { ClientCommand, DiscImageUri, NO_DISC } from '../types/shared/messages'
+import { ClientCommand, DiscImageFile, NO_DISC } from '../types/shared/messages'
 
 const audioFilterFreq = 7000
 const audioFilterQ = 5
@@ -22,14 +22,14 @@ export class EmulatorView {
   model: Model | undefined
   emulator: Emulator | undefined // Dont hold references to the emulator, it may be paused and destroyed
 
-  mountedDisc: DiscImageUri | undefined
+  mountedDisc: DiscImageFile | undefined
 
-  private _discImages$ = new BehaviorSubject<DiscImageUri[]>([])
-  get discImages$(): Observable<DiscImageUri[]> {
+  private _discImages$ = new BehaviorSubject<DiscImageFile[]>([])
+  get discImages$(): Observable<DiscImageFile[]> {
     return this._discImages$
   }
 
-  setDiscImages(discImages: DiscImageUri[]) {
+  setDiscImages(discImages: DiscImageFile[]) {
     this._discImages$.next(discImages)
   }
 
@@ -149,11 +149,11 @@ export class EmulatorView {
     this.screen.focus()
   }
 
-  async mountDisc(discImageFile: DiscImageUri, autoBoot: boolean = false) {
+  async mountDisc(discImageFile: DiscImageFile, autoBoot: boolean = false) {
     console.log(`mountDisc=${discImageFile}`)
     this.mountedDisc = discImageFile
     if (this.emulator) {
-      await this.emulator.loadDisc(discImageFile.uri)
+      await this.emulator.loadDisc(discImageFile.url)
       if (autoBoot) {
         this.emulator.holdShift()
       }
@@ -175,7 +175,7 @@ export class EmulatorView {
     if (this.emulator) {
       this.emulator.cpu.reset(hard)
       if (this.mountedDisc) {
-        await this.emulator.loadDisc(this.mountedDisc.uri)
+        await this.emulator.loadDisc(this.mountedDisc.url)
       }
     }
   }

--- a/src/scripts/emulator-view.ts
+++ b/src/scripts/emulator-view.ts
@@ -6,7 +6,7 @@ import { CustomAudioHandler } from './custom-audio-handler'
 import { BehaviorSubject, Observable, distinctUntilChanged } from 'rxjs'
 import { DisplayMode, getDisplayModeInfo } from './display-modes'
 import { notifyHost } from './vscode'
-import { ClientCommand } from '../types/shared/messages'
+import { ClientCommand, DiscImageUri } from '../types/shared/messages'
 
 const audioFilterFreq = 7000
 const audioFilterQ = 5
@@ -23,6 +23,15 @@ export class EmulatorView {
   emulator: Emulator | undefined // Dont hold references to the emulator, it may be paused and destroyed
 
   mountedDisc: string | undefined
+
+  private _discImages$ = new BehaviorSubject<DiscImageUri[]>([])
+  get discImages$(): Observable<DiscImageUri[]> {
+    return this._discImages$
+  }
+
+  setDiscImages(discImages: DiscImageUri[]) {
+    this._discImages$.next(discImages)
+  }
 
   // observables
   private _displayMode$ = new BehaviorSubject<DisplayMode>(null)

--- a/src/scripts/emulator-view.ts
+++ b/src/scripts/emulator-view.ts
@@ -117,7 +117,7 @@ export class EmulatorView {
       await this.emulator.initialise()
 
       // re-mount any existing disc if we change model
-      this.reloadDisc()
+      this.mountDisc(this.discImageFile)
 
       this.emulator.start()
       // will automatically unsubscribe when emulator is shutdown
@@ -164,42 +164,13 @@ export class EmulatorView {
     discImageFile: DiscImageFile,
     discImageOptions?: DiscImageOptions,
   ): Promise<boolean> {
-    if (!this.emulator) {
-      return false
-    }
-    if (discImageFile.url) {
-      const loaded = await this.emulator.loadDisc(
-        discImageFile,
-        discImageOptions,
-      )
-      if (loaded) {
-        this._discImageFile$.next(discImageFile)
-        return true
-      }
-    }
-    this.unmountDisc()
-    return false
-  }
-
-  unmountDisc() {
-    if (this.emulator) {
-      this.emulator.ejectDisc()
-      this._discImageFile$.next(NO_DISC)
-      notifyHost({
-        command: ClientCommand.Error,
-        text: `Disc ejected`,
-      })
-    }
-  }
-
-  async reloadDisc() {
-    await this.mountDisc(this._discImageFile$.value)
+    this.emulator?.loadDisc(discImageFile, discImageOptions)
+    this._discImageFile$.next(discImageFile)
+    return true
   }
 
   async resetCpu(hard: boolean = false) {
-    if (this.emulator) {
-      this.emulator.resetCpu(hard)
-      // await this.reloadDisc()
-    }
+    this.emulator?.resetCpu(hard)
+    await this.mountDisc(this.discImageFile)
   }
 }

--- a/src/scripts/emulator.ts
+++ b/src/scripts/emulator.ts
@@ -190,8 +190,10 @@ export class Emulator {
   }
 
   ejectDisc() {
-    console.log('ejecting disc')
-    emptySsd(this.cpu.fdc)
+    console.log('Disc ejected')
+    const blank = emptySsd(this.cpu.fdc)
+    this.cpu.fdc.loadDisc(0, blank)
+    this.cpu.fdc.loadDisc(2, blank)
   }
 
   async runProgram(tokenised: any) {

--- a/src/scripts/emulator.ts
+++ b/src/scripts/emulator.ts
@@ -192,15 +192,14 @@ export class Emulator {
     }
     if (discImageFile.url) {
       try {
-        console.log('loading disc')
         const fdc = this.cpu.fdc
         const discData = await utils.defaultLoadData(discImageFile.url)
         const discImage = new BaseDisc(fdc, 'disc', discData, () => {})
         this.cpu.fdc.loadDisc(0, discImage)
-        notifyHost({
-          command: ClientCommand.Error,
-          text: `Mounted disc '${discImageFile.name}'`,
-        })
+        // notifyHost({
+        //   command: ClientCommand.Info,
+        //   text: `Mounted disc '${discImageFile.name}'`,
+        // })
         if (discImageOptions?.shouldReset) {
           this.resetCpu(false)
         }

--- a/src/scripts/emulator.ts
+++ b/src/scripts/emulator.ts
@@ -175,6 +175,13 @@ export class Emulator {
     this._emulatorUpdate$.complete()
   }
 
+  /**
+   * Load a disc image into the emulator
+   * If the disc url is empty, the disc drive will be set to empty
+   * @param discImageFile - the disc image file to load, or NO_DISC for an empty drive
+   * @param discImageOptions - options for loading the disc image
+   * @returns true if the disc was loaded successfully
+   */
   async loadDisc(
     discImageFile: DiscImageFile,
     discImageOptions?: DiscImageOptions,

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -38,9 +38,8 @@ async function initialise() {
 }
 
 // Handle the message inside the webview
-window.addEventListener('load', (event) => {
-  console.log('window loaded')
-  console.log(JSON.stringify(event))
+window.addEventListener('load', (_event) => {
+  console.log('BeebVSC: Emulator window loaded')
   notifyHost({ command: ClientCommand.PageLoaded })
 })
 
@@ -48,7 +47,6 @@ window.addEventListener('load', (event) => {
 window.addEventListener(
   'focus',
   (_event) => {
-    console.log('window focused')
     emulatorView.focusInput()
   },
   false,
@@ -57,9 +55,6 @@ window.addEventListener(
 // Handle messages received from the host extensiond
 window.addEventListener('message', (event) => {
   const message = event.data as HostMessage // The JSON data our extension sent
-  console.log('message received')
-  console.log(JSON.stringify(message))
-
   switch (message.command) {
     case HostCommand.LoadDisc:
       // user has invoked a dsd/ssd file context menu for the emulator
@@ -70,14 +65,13 @@ window.addEventListener('message', (event) => {
       // Emulator panel has changed active or visible state
       // We handle focus via window events at the moment
       // since these can arrive before the webview is ready
+      // but we may want to do something with visibility or active state later
       break
     case HostCommand.DiscImages:
-      if (message.discImages) {
-        emulatorView.setDiscImages(message.discImages)
-      }
+      emulatorView.setDiscImages(message.discImages)
       break
     case HostCommand.DiscImageChanges:
-      //TODO: Listener logic here
+      //TODO: Listener logic here, in case we need to do something with modified disc images
       break
   }
 })

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -63,13 +63,11 @@ window.addEventListener('message', (event) => {
   switch (message.command) {
     case HostCommand.LoadDisc:
       // user has invoked a dsd/ssd file context menu for the emulator
-      if (message.discImageFile) {
-        emulatorView.emulator?.loadDisc(message.discImageFile, true)
-        emulatorToolBar?.discSelector.val(
-          `${message.discImageFile.url}|${message.discImageFile.name}`,
-        )
-        emulatorView.focusInput()
-      }
+      emulatorView.loadDisc(message.discImageFile, message.discImageOptions)
+      emulatorToolBar?.discSelector.val(
+        `${message.discImageFile.url}|${message.discImageFile.name}`,
+      )
+      emulatorView.focusInput()
       break
     case HostCommand.ViewFocus:
       // Emulator panel has changed active or visible state

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -64,7 +64,7 @@ window.addEventListener('message', (event) => {
     case HostCommand.LoadDisc:
       // user has invoked a dsd/ssd file context menu for the emulator
       if (message.url) {
-        emulatorView.mountDisc(message.url, true)
+        emulatorView.emulator?.loadDisc(message.url, true)
       }
       break
     case HostCommand.ViewFocus:

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -64,9 +64,6 @@ window.addEventListener('message', (event) => {
     case HostCommand.LoadDisc:
       // user has invoked a dsd/ssd file context menu for the emulator
       emulatorView.mountDisc(message.discImageFile, message.discImageOptions)
-      // emulatorToolBar?.discSelector.val(
-      //   `${message.discImageFile.url}|${message.discImageFile.name}`,
-      // )
       emulatorView.focusInput()
       break
     case HostCommand.ViewFocus:

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -62,19 +62,23 @@ window.addEventListener('message', (event) => {
 
   switch (message.command) {
     case HostCommand.LoadDisc:
+      // user has invoked a dsd/ssd file context menu for the emulator
       if (message.url) {
         emulatorView.mountDisc(message.url, true)
       }
       break
     case HostCommand.ViewFocus:
-      // if (message.isViewFocused) {
-      //   emulatorView.focus()
-      // }
+      // Emulator panel has changed active or visible state
+      // We handle focus via window events at the moment
+      // since these can arrive before the webview is ready
       break
     case HostCommand.DiscImages:
       if (message.discImages) {
         emulatorView.setDiscImages(message.discImages)
       }
+      break
+    case HostCommand.DiscImageChanges:
+      //TODO: Listener logic here
       break
   }
 })

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -65,6 +65,10 @@ window.addEventListener('message', (event) => {
       // user has invoked a dsd/ssd file context menu for the emulator
       if (message.url) {
         emulatorView.emulator?.loadDisc(message.url, true)
+        emulatorToolBar?.discSelector.val(
+          `${message.url.url}|${message.url.name}`,
+        )
+        emulatorView.focusInput()
       }
       break
     case HostCommand.ViewFocus:

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -63,10 +63,10 @@ window.addEventListener('message', (event) => {
   switch (message.command) {
     case HostCommand.LoadDisc:
       // user has invoked a dsd/ssd file context menu for the emulator
-      emulatorView.loadDisc(message.discImageFile, message.discImageOptions)
-      emulatorToolBar?.discSelector.val(
-        `${message.discImageFile.url}|${message.discImageFile.name}`,
-      )
+      emulatorView.mountDisc(message.discImageFile, message.discImageOptions)
+      // emulatorToolBar?.discSelector.val(
+      //   `${message.discImageFile.url}|${message.discImageFile.name}`,
+      // )
       emulatorView.focusInput()
       break
     case HostCommand.ViewFocus:

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -63,10 +63,10 @@ window.addEventListener('message', (event) => {
   switch (message.command) {
     case HostCommand.LoadDisc:
       // user has invoked a dsd/ssd file context menu for the emulator
-      if (message.url) {
-        emulatorView.emulator?.loadDisc(message.url, true)
+      if (message.discImageFile) {
+        emulatorView.emulator?.loadDisc(message.discImageFile, true)
         emulatorToolBar?.discSelector.val(
-          `${message.url.url}|${message.url.name}`,
+          `${message.discImageFile.url}|${message.discImageFile.name}`,
         )
         emulatorView.focusInput()
       }

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -71,6 +71,11 @@ window.addEventListener('message', (event) => {
       //   emulatorView.focus()
       // }
       break
+    case HostCommand.DiscImages:
+      if (message.discImages) {
+        emulatorView.setDiscImages(message.discImages)
+      }
+      break
   }
 })
 

--- a/src/types/shared/messages.ts
+++ b/src/types/shared/messages.ts
@@ -69,7 +69,7 @@ export interface HostMessageDiscImageChanges extends HostMessageBase {
 
 export interface HostMessageLoadDisc extends HostMessageBase {
   command: HostCommand.LoadDisc
-  url: DiscImageFile
+  discImageFile: DiscImageFile
 }
 
 export interface HostMessageViewFocus extends HostMessageBase {

--- a/src/types/shared/messages.ts
+++ b/src/types/shared/messages.ts
@@ -37,12 +37,12 @@ export type ClientMessage =
  * Messages from host to client
  */
 
-export type DiscImageUri = {
-  uri: string
+export type DiscImageFile = {
+  url: string
   name: string
 }
 
-export const NO_DISC: DiscImageUri = { uri: '', name: '-- no disc --' }
+export const NO_DISC: DiscImageFile = { url: '', name: '-- no disc --' }
 
 export const enum HostCommand {
   LoadDisc = 'loadDisc',
@@ -57,21 +57,21 @@ export interface HostMessageBase extends MessageBase {
 
 export interface HostMessageDiscImages extends HostMessageBase {
   command: HostCommand.DiscImages
-  discImages: DiscImageUri[]
+  discImages: DiscImageFile[]
 }
 
 export interface HostMessageDiscImageChanges extends HostMessageBase {
   command: HostCommand.DiscImageChanges
   discImageChanges: {
-    changed?: DiscImageUri[]
-    created?: DiscImageUri[]
-    deleted?: DiscImageUri[]
+    changed?: DiscImageFile[]
+    created?: DiscImageFile[]
+    deleted?: DiscImageFile[]
   }
 }
 
 export interface HostMessageLoadDisc extends HostMessageBase {
   command: HostCommand.LoadDisc
-  url: DiscImageUri
+  url: DiscImageFile
 }
 
 export interface HostMessageViewFocus extends HostMessageBase {

--- a/src/types/shared/messages.ts
+++ b/src/types/shared/messages.ts
@@ -2,7 +2,9 @@ export interface MessageBase {
   command: string
 }
 
-// Message from client to host
+/**
+ * Messages from client to host
+ */
 export const enum ClientCommand {
   EmulatorReady = 'emulatorReady',
   PageLoaded = 'pageLoaded',
@@ -14,10 +16,20 @@ export interface ClientMessage extends MessageBase {
   text?: string
 }
 
-// Message from host to client
+/**
+ * Messages from host to client
+ */
+
+export type DiscImageUri = {
+  uri: string
+  name: string
+}
+
 export const enum HostCommand {
   LoadDisc = 'loadDisc',
   ViewFocus = 'viewFocus',
+  DiscImages = 'discImages',
+  DiscImageChanges = 'discImageChanges',
 }
 
 export interface HostMessage extends MessageBase {
@@ -26,5 +38,11 @@ export interface HostMessage extends MessageBase {
   focus?: {
     active: boolean
     visible: boolean
+  }
+  discImages?: DiscImageUri[]
+  discImageChanges?: {
+    changed?: DiscImageUri[]
+    created?: DiscImageUri[]
+    deleted?: DiscImageUri[]
   }
 }

--- a/src/types/shared/messages.ts
+++ b/src/types/shared/messages.ts
@@ -42,6 +42,8 @@ export type DiscImageUri = {
   name: string
 }
 
+export const NO_DISC: DiscImageUri = { uri: '', name: '-- no disc --' }
+
 export const enum HostCommand {
   LoadDisc = 'loadDisc',
   ViewFocus = 'viewFocus',
@@ -69,7 +71,7 @@ export interface HostMessageDiscImageChanges extends HostMessageBase {
 
 export interface HostMessageLoadDisc extends HostMessageBase {
   command: HostCommand.LoadDisc
-  url: string
+  url: DiscImageUri
 }
 
 export interface HostMessageViewFocus extends HostMessageBase {

--- a/src/types/shared/messages.ts
+++ b/src/types/shared/messages.ts
@@ -42,6 +42,11 @@ export type DiscImageFile = {
   name: string
 }
 
+export type DiscImageOptions = {
+  shouldReset?: boolean
+  shouldAutoBoot?: boolean
+}
+
 export const NO_DISC: DiscImageFile = { url: '', name: '-- no disc --' }
 
 export const enum HostCommand {
@@ -70,6 +75,7 @@ export interface HostMessageDiscImageChanges extends HostMessageBase {
 export interface HostMessageLoadDisc extends HostMessageBase {
   command: HostCommand.LoadDisc
   discImageFile: DiscImageFile
+  discImageOptions?: DiscImageOptions
 }
 
 export interface HostMessageViewFocus extends HostMessageBase {

--- a/src/types/shared/messages.ts
+++ b/src/types/shared/messages.ts
@@ -11,10 +11,27 @@ export const enum ClientCommand {
   Error = 'error',
 }
 
-export interface ClientMessage extends MessageBase {
+export interface ClientMessageBase extends MessageBase {
   command: ClientCommand
-  text?: string
 }
+
+export interface ClientMessageEmulatorReady extends ClientMessageBase {
+  command: ClientCommand.EmulatorReady
+}
+
+export interface ClientMessagePageLoaded extends ClientMessageBase {
+  command: ClientCommand.PageLoaded
+}
+
+export interface ClientMessageError extends ClientMessageBase {
+  command: ClientCommand.Error
+  text: string
+}
+
+export type ClientMessage =
+  | ClientMessageEmulatorReady
+  | ClientMessagePageLoaded
+  | ClientMessageError
 
 /**
  * Messages from host to client
@@ -32,17 +49,39 @@ export const enum HostCommand {
   DiscImageChanges = 'discImageChanges',
 }
 
-export interface HostMessage extends MessageBase {
+export interface HostMessageBase extends MessageBase {
   command: HostCommand
-  url?: string
-  focus?: {
-    active: boolean
-    visible: boolean
-  }
-  discImages?: DiscImageUri[]
-  discImageChanges?: {
+}
+
+export interface HostMessageDiscImages extends HostMessageBase {
+  command: HostCommand.DiscImages
+  discImages: DiscImageUri[]
+}
+
+export interface HostMessageDiscImageChanges extends HostMessageBase {
+  command: HostCommand.DiscImageChanges
+  discImageChanges: {
     changed?: DiscImageUri[]
     created?: DiscImageUri[]
     deleted?: DiscImageUri[]
   }
 }
+
+export interface HostMessageLoadDisc extends HostMessageBase {
+  command: HostCommand.LoadDisc
+  url: string
+}
+
+export interface HostMessageViewFocus extends HostMessageBase {
+  command: HostCommand.ViewFocus
+  focus: {
+    active: boolean
+    visible: boolean
+  }
+}
+
+export type HostMessage =
+  | HostMessageDiscImages
+  | HostMessageDiscImageChanges
+  | HostMessageLoadDisc
+  | HostMessageViewFocus

--- a/src/types/shared/messages.ts
+++ b/src/types/shared/messages.ts
@@ -62,11 +62,9 @@ export interface HostMessageDiscImages extends HostMessageBase {
 
 export interface HostMessageDiscImageChanges extends HostMessageBase {
   command: HostCommand.DiscImageChanges
-  discImageChanges: {
-    changed?: DiscImageFile[]
-    created?: DiscImageFile[]
-    deleted?: DiscImageFile[]
-  }
+  changed?: DiscImageFile[]
+  created?: DiscImageFile[]
+  deleted?: DiscImageFile[]
 }
 
 export interface HostMessageLoadDisc extends HostMessageBase {

--- a/src/types/shared/messages.ts
+++ b/src/types/shared/messages.ts
@@ -8,6 +8,7 @@ export interface MessageBase {
 export const enum ClientCommand {
   EmulatorReady = 'emulatorReady',
   PageLoaded = 'pageLoaded',
+  Info = 'info',
   Error = 'error',
 }
 
@@ -23,6 +24,10 @@ export interface ClientMessagePageLoaded extends ClientMessageBase {
   command: ClientCommand.PageLoaded
 }
 
+export interface ClientMessageInfo extends ClientMessageBase {
+  command: ClientCommand.Info
+  text: string
+}
 export interface ClientMessageError extends ClientMessageBase {
   command: ClientCommand.Error
   text: string
@@ -31,6 +36,7 @@ export interface ClientMessageError extends ClientMessageBase {
 export type ClientMessage =
   | ClientMessageEmulatorReady
   | ClientMessagePageLoaded
+  | ClientMessageInfo
   | ClientMessageError
 
 /**


### PR DESCRIPTION
Disc selection toolbar now works.
* Adds a workspace file watcher to the extension, so `*.dsd` and `*.ssd` files (+changes) are automatically detected
* Emulator disc selection dropdown now populates with all disc images in workspace
* Can select an empty disc
* Disc selector updates when disc images are selected via vscode context menu
* Rebooting emulator will reload the correct disc image
* Cleaned up logs
* Added Error & Info host notification message types
* Fixed the runtime info box since it wrapped after 24hours