### PR TITLE
feat: Addressing consistency checks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
 	"editor.codeActionsOnSave": {
 		"source.fixAll.eslint": "explicit"
 	},
-	"mochaExplorer.files": "server/out/test/*.js",
+	"mochaExplorer.files": "out/server/test/*.js",
 	"mochaExplorer.require": "source-map-support/register",
-	"mochaExplorer.watch": "server/out/test/*.js"
+	"mochaExplorer.watch": "out/server/test/*.js"
 }

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Select the one that you wish to assemble with `BeebAsm`, and a new build target 
 
 ![Screenshot](./docs/images/targetcreated.png?raw=true)
 
-A `tasks.json` file will be created in a `.vscode` folder in your workspace containing the required tasks to build or run your targets.
+A `tasks.json` file will be created in a `.vscode` folder in your workspace containing the required tasks to build or run your targets. A `settings.json` file will also be created in the same location and is used for identifying the target source file(s) so we can parse the files in a suitable order even when viewing a different source file.
 
 ![Screenshot](./docs/images/tasksjson.png?raw=true)
 
@@ -131,6 +131,21 @@ The BeebVSC extension is careful to preserve the contents of the `tasks.json` fi
 The only property that is managed by the extension is `Group -> Kind`, so this is subject to modification.
 Note also that the commandline argument for the test task is managed by the extension, and updates whenever a new build target is selected.
 
+## Directly managing target source files
+If you don't want to use BeebVSC's functionality to add build targets, some functionality will be limited because the extension will not know what order INCLUDE files are processed. In this case, it is necessary to add the target file(s) to the `settings.json` file. For example, if the targets `build.asm` and `loader.asm` are run through BeebAsm then the settings file would look like: 
+```json
+{
+    "beebvsc": {
+        "sourceFile": [
+            "/Users/Games/Test/build.asm",
+            "/Users/Games/Test/loader.asm"
+        ],
+        "targetName": "main.ssd"
+    }
+}
+```
+The easiest way to set this up is adding the build targets in a normal way and they removing the `tasks.json` entries if those are not wanted.
+
 ## Command Line format
 Due to constraints in the way that Visual Studio Code handles tasks, BeebVSC tasks must be executed as single arguments to a shell such as `"cmd.exe"`.
 
@@ -139,6 +154,8 @@ The installation is for Windows by default, but its quite feasible to get it wor
 
 # Release notes
 
+- **0.1.2** - Tweaks to completions
+- **0.1.1** - Substantial internal refactoring and minor bug fixes
 - **0.1.0** - Move to LSP client/server structure, add hovers, completions, diagnostics and reference finding
 - **0.0.6** - Added full build environment support via JS script to extension
 - **0.0.5** - Test version

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
 		"test:server": "ts-mocha server/src/test/*.ts",
 		"pretest:client": "npm run compile && npm run lint",
 		"test_orig:client": "node ./client/out/test/runTest.js",
-		"test:client": "node ./server/out/test/tests.js"
+		"test:client": "node ./out/server/test/tests.js"
 	},
 	"devDependencies": {
 		"@types/jquery": "^3.5.29",

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -32,7 +32,7 @@ let client: LanguageClient
 
 interface BeebVSCSettings {
   beebvsc: {
-    sourceFile: string
+    sourceFile: string | string[]
     targetName: string
   }
 }
@@ -285,7 +285,7 @@ function CreateNewLocalSettingsJson(sourceFile: string, targetName: string) {
 
   const settingsObject: BeebVSCSettings = {
     beebvsc: {
-      sourceFile: sourcePath,
+      sourceFile: [sourcePath],
       targetName: targetName,
     },
   }
@@ -315,7 +315,7 @@ function setCurrentTarget(
             // no target file specified, so use the default target file
             targetFile = getTargetName(
               workspace.getConfiguration('beebvsc').get<string>('sourceFile') ??
-                'main.asm',
+              'main.asm',
             )
           }
         }
@@ -540,8 +540,20 @@ function SaveJSONFiles(
     }
     // now add the new settings
     console.log('Setting beebvsc object to settings.json')
+    const currentSourceFile = settingsObject.beebvsc?.sourceFile
+    let newSourceFile: string[] = []
+    if (typeof currentSourceFile === 'string') {
+      newSourceFile.push(currentSourceFile)
+    } else if (Array.isArray(currentSourceFile)) {
+      newSourceFile = currentSourceFile ?? []
+    } else {
+      newSourceFile = []
+    }
+    if (!newSourceFile.includes(path.join(rootPath, selection))) {
+      newSourceFile.push(path.join(rootPath, selection))
+    }
     settingsObject.beebvsc = {
-      sourceFile: path.join(rootPath, selection),
+      sourceFile: newSourceFile,
       targetName: targetDiskImage,
     }
 

--- a/src/server/beebasm-ts/lineparser.ts
+++ b/src/server/beebasm-ts/lineparser.ts
@@ -1,24 +1,24 @@
 /*************************************************************************************************/
 /**
-	Derived from lineparser.cpp/h and other files in the same namespace
+  Derived from lineparser.cpp/h and other files in the same namespace
 
-	Represents a line of the source file
+  Represents a line of the source file
 
 
-	Copyright (C) Rich Talbot-Watkins 2007 - 2012
+  Copyright (C) Rich Talbot-Watkins 2007 - 2012
 
-	This file is part of BeebAsm.
+  This file is part of BeebAsm.
 
-	BeebAsm is free software: you can redistribute it and/or modify it under the terms of the GNU
-	General Public License as published by the Free Software Foundation, either version 3 of the
-	License, or (at your option) any later version.
+  BeebAsm is free software: you can redistribute it and/or modify it under the terms of the GNU
+  General Public License as published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
 
-	BeebAsm is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
-	even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+  BeebAsm is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+  even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License along with BeebAsm, as
-	COPYING.txt.  If not, see <http://www.gnu.org/licenses/>.
+  You should have received a copy of the GNU General Public License along with BeebAsm, as
+  COPYING.txt.  If not, see <http://www.gnu.org/licenses/>.
 */
 /*************************************************************************************************/
 
@@ -2302,7 +2302,7 @@ export class LineParser {
             while (
               this._operatorStackPtr > 0 &&
               thisOp.precedence <
-                this._operatorStack[this._operatorStackPtr - 1].precedence
+              this._operatorStack[this._operatorStackPtr - 1].precedence
             ) {
               this._operatorStackPtr--
               const opHandler =
@@ -2382,7 +2382,7 @@ export class LineParser {
           while (
             this._operatorStackPtr > 0 &&
             thisOp.precedence <=
-              this._operatorStack[this._operatorStackPtr - 1].precedence
+            this._operatorStack[this._operatorStackPtr - 1].precedence
           ) {
             this._operatorStackPtr--
             const opHandler =
@@ -2600,10 +2600,10 @@ export class LineParser {
     let double_value: number
     let canParse: boolean
     let isSymbol = false
-    ;[canParse, this._column, double_value] = this.ParseNumeric(
-      this._line,
-      this._column,
-    )
+      ;[canParse, this._column, double_value] = this.ParseNumeric(
+        this._line,
+        this._column,
+      )
     if (canParse) {
       value = double_value
     } else if (
@@ -2684,10 +2684,10 @@ export class LineParser {
           },
         }
         let hasValue: boolean
-        ;[hasValue, value] = this._sourceCode.GetSymbolValue(
-          symbolName,
-          location,
-        )
+          ;[hasValue, value] = this._sourceCode.GetSymbolValue(
+            symbolName,
+            location,
+          )
         if (!hasValue) {
           // symbol not known
           throw new AsmException.SyntaxError_SymbolNotDefined(
@@ -2733,21 +2733,21 @@ export class LineParser {
       // Copy digits preceding decimal point
       let have_digits: boolean
       let have_digits_post = false
-      ;[have_digits, index, buffer] = this.CopyDigitsSkippingUnderscores(
-        line,
-        index,
-        buffer,
-      )
-      // Copy decimal point
-      if (index < line.length && line[index] == '.') {
-        buffer += line[index]
-        index++
-        // Copy digits after decimal point
-        ;[have_digits_post, index, buffer] = this.CopyDigitsSkippingUnderscores(
+        ;[have_digits, index, buffer] = this.CopyDigitsSkippingUnderscores(
           line,
           index,
           buffer,
         )
+      // Copy decimal point
+      if (index < line.length && line[index] == '.') {
+        buffer += line[index]
+        index++
+          // Copy digits after decimal point
+          ;[have_digits_post, index, buffer] = this.CopyDigitsSkippingUnderscores(
+            line,
+            index,
+            buffer,
+          )
       }
       if (!(have_digits || have_digits_post)) {
         // A decimal point with no number will cause this
@@ -2768,11 +2768,11 @@ export class LineParser {
           index++
         }
         let have_digits_exp: boolean
-        ;[have_digits_exp, index, buffer] = this.CopyDigitsSkippingUnderscores(
-          line,
-          index,
-          buffer,
-        )
+          ;[have_digits_exp, index, buffer] = this.CopyDigitsSkippingUnderscores(
+            line,
+            index,
+            buffer,
+          )
         if (!have_digits_exp) {
           // Exponent needs a value
           // throw new AsmException.SyntaxError_InvalidCharacter( line, index );
@@ -2786,7 +2786,7 @@ export class LineParser {
       // skip the number prefix
       index++
       let can_parse: boolean
-      ;[can_parse, index, result] = this.ParseInteger(line, index, 16, 8)
+        ;[can_parse, index, result] = this.ParseInteger(line, index, 16, 8)
       if (!can_parse) {
         // badly formed hex literal
         // throw new AsmException.SyntaxError_BadHex( line, index );
@@ -2797,7 +2797,7 @@ export class LineParser {
       // skip the number prefix
       index++
       let can_parse: boolean
-      ;[can_parse, index, result] = this.ParseInteger(line, index, 2, 32)
+        ;[can_parse, index, result] = this.ParseInteger(line, index, 2, 32)
       if (!can_parse) {
         // badly formed bin literal
         // throw new AsmException.SyntaxError_BadBin( line, index );
@@ -3578,8 +3578,10 @@ export class LineParser {
           typeof value !== 'number' ||
           value !== ObjectCode.Instance.GetPC()
         ) {
-          // TODO - reenable ideally but may not be possible if want to avoid iterating loops (needs multi-file symbol resolution too)
-          // throw new AsmException.SyntaxError_SecondPassProblem(this._line, oldColumn);
+          throw new AsmException.SyntaxError_SecondPassProblem(
+            this._line,
+            oldColumn,
+          )
         }
         SymbolTable.Instance.AddLabel(symbolName)
       }

--- a/src/server/beebasm-ts/objectcode.ts
+++ b/src/server/beebasm-ts/objectcode.ts
@@ -43,6 +43,9 @@ export class ObjectCode {
   private _aMemory: number[] = new Array(0x10000)
   private _aFlags: number[] = new Array(0x10000)
   private _aMapChar: integer[] = new Array(96)
+  // After one consistency error, all subsequent code will probably be wrong, so just raise once
+  // or we'll get a lot of errors and potentially cause severe slowdown
+  private _hadConsistencyError = false
 
   private constructor() {
     //SymbolTable.Instance.AddSymbol( "CPU", this._CPU );
@@ -58,6 +61,7 @@ export class ObjectCode {
     this._aMemory.fill(0)
     this._aFlags.fill(0)
     this._aMapChar.fill(0)
+    this._hadConsistencyError = false
   }
 
   public GetCPU(): number {
@@ -196,7 +200,10 @@ export class ObjectCode {
       !(this._aFlags[this._PC] & FLAGS.DONT_CHECK) &&
       this._aMemory[this._PC] !== opcode
     ) {
-      throw new AsmException.AssembleError_InconsistentCode()
+      if (!this._hadConsistencyError) {
+        this._hadConsistencyError = true
+        throw new AsmException.AssembleError_InconsistentCode()
+      }
     }
     if (this._aFlags[this._PC] & FLAGS.GUARD) {
       throw new AsmException.AssembleError_GuardHit()
@@ -219,7 +226,10 @@ export class ObjectCode {
       !(this._aFlags[this._PC] & FLAGS.DONT_CHECK) &&
       this._aMemory[this._PC] !== opcode
     ) {
-      throw new AsmException.AssembleError_InconsistentCode()
+      if (!this._hadConsistencyError) {
+        this._hadConsistencyError = true
+        throw new AsmException.AssembleError_InconsistentCode()
+      }
     }
     if (this._aFlags[this._PC] & FLAGS.GUARD) {
       throw new AsmException.AssembleError_GuardHit()
@@ -244,7 +254,10 @@ export class ObjectCode {
       !(this._aFlags[this._PC] & FLAGS.DONT_CHECK) &&
       this._aMemory[this._PC] !== opcode
     ) {
-      throw new AsmException.AssembleError_InconsistentCode()
+      if (!this._hadConsistencyError) {
+        this._hadConsistencyError = true
+        throw new AsmException.AssembleError_InconsistentCode()
+      }
     }
     if (
       this._aFlags[this._PC] & FLAGS.GUARD ||

--- a/src/server/beebasm-ts/objectcode.ts
+++ b/src/server/beebasm-ts/objectcode.ts
@@ -1,22 +1,22 @@
 /*************************************************************************************************/
 /**
-	Derived from objectcode.cpp/h
+  Derived from objectcode.cpp/h
 
 
-	Copyright (C) Rich Talbot-Watkins 2007 - 2012
+  Copyright (C) Rich Talbot-Watkins 2007 - 2012
 
-	This file is part of BeebAsm.
+  This file is part of BeebAsm.
 
-	BeebAsm is free software: you can redistribute it and/or modify it under the terms of the GNU
-	General Public License as published by the Free Software Foundation, either version 3 of the
-	License, or (at your option) any later version.
+  BeebAsm is free software: you can redistribute it and/or modify it under the terms of the GNU
+  General Public License as published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
 
-	BeebAsm is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
-	even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+  BeebAsm is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+  even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License along with BeebAsm, as
-	COPYING.txt.  If not, see <http://www.gnu.org/licenses/>.
+  You should have received a copy of the GNU General Public License along with BeebAsm, as
+  COPYING.txt.  If not, see <http://www.gnu.org/licenses/>.
 */
 /*************************************************************************************************/
 
@@ -196,8 +196,7 @@ export class ObjectCode {
       !(this._aFlags[this._PC] & FLAGS.DONT_CHECK) &&
       this._aMemory[this._PC] !== opcode
     ) {
-      // TODO - reenable this check if can resolve other issues that prevent code from staying consistent
-      // throw new AsmException.AssembleError_InconsistentCode();
+      throw new AsmException.AssembleError_InconsistentCode()
     }
     if (this._aFlags[this._PC] & FLAGS.GUARD) {
       throw new AsmException.AssembleError_GuardHit()
@@ -220,7 +219,7 @@ export class ObjectCode {
       !(this._aFlags[this._PC] & FLAGS.DONT_CHECK) &&
       this._aMemory[this._PC] !== opcode
     ) {
-      // throw new AsmException.AssembleError_InconsistentCode();
+      throw new AsmException.AssembleError_InconsistentCode()
     }
     if (this._aFlags[this._PC] & FLAGS.GUARD) {
       throw new AsmException.AssembleError_GuardHit()
@@ -245,7 +244,7 @@ export class ObjectCode {
       !(this._aFlags[this._PC] & FLAGS.DONT_CHECK) &&
       this._aMemory[this._PC] !== opcode
     ) {
-      // throw new AsmException.AssembleError_InconsistentCode();
+      throw new AsmException.AssembleError_InconsistentCode()
     }
     if (
       this._aFlags[this._PC] & FLAGS.GUARD ||

--- a/src/server/beebasm-ts/sourcefile.ts
+++ b/src/server/beebasm-ts/sourcefile.ts
@@ -1,28 +1,29 @@
 /*************************************************************************************************/
 /**
-	Derived from sourcefile.cpp/h
+  Derived from sourcefile.cpp/h
 
-	Assembles a file
+  Assembles a file
 
 
-	Copyright (C) Rich Talbot-Watkins 2007 - 2012
+  Copyright (C) Rich Talbot-Watkins 2007 - 2012
 
-	This file is part of BeebAsm.
+  This file is part of BeebAsm.
 
-	BeebAsm is free software: you can redistribute it and/or modify it under the terms of the GNU
-	General Public License as published by the Free Software Foundation, either version 3 of the
-	License, or (at your option) any later version.
+  BeebAsm is free software: you can redistribute it and/or modify it under the terms of the GNU
+  General Public License as published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
 
-	BeebAsm is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
-	even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+  BeebAsm is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+  even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License along with BeebAsm, as
-	COPYING.txt.  If not, see <http://www.gnu.org/licenses/>.
+  You should have received a copy of the GNU General Public License along with BeebAsm, as
+  COPYING.txt.  If not, see <http://www.gnu.org/licenses/>.
 */
 /*************************************************************************************************/
 
 import { AST } from '../ast'
+import { FileHandler } from '../filehandler'
 import { SourceCode } from './sourcecode'
 import { Diagnostic, DocumentLink, URI } from 'vscode-languageserver'
 
@@ -36,7 +37,12 @@ export class SourceFile extends SourceCode {
     links: Map<string, DocumentLink[]>,
   ) {
     super(contents, 0, parent, diagnostics, uri, trees, links)
-    // console.log(`SourceFile constructor called for ${uri}`);
+    // set self-reference in source to parent map if this is a root file
+    if (parent === null) {
+      FileHandler.Instance.SetTargetFileName(uri, uri)
+    } else {
+      FileHandler.Instance.SetTargetFileName(uri, parent.GetURI())
+    }
   }
 
   GetLine(lineNumber: number): string {

--- a/src/server/beebasm-ts/symboltable.ts
+++ b/src/server/beebasm-ts/symboltable.ts
@@ -1,22 +1,22 @@
 /*************************************************************************************************/
 /**
-	Derived from symboltable.cpp/h
+  Derived from symboltable.cpp/h
 
 
-	Copyright (C) Rich Talbot-Watkins 2007 - 2012
+  Copyright (C) Rich Talbot-Watkins 2007 - 2012
 
-	This file is part of BeebAsm.
+  This file is part of BeebAsm.
 
-	BeebAsm is free software: you can redistribute it and/or modify it under the terms of the GNU
-	General Public License as published by the Free Software Foundation, either version 3 of the
-	License, or (at your option) any later version.
+  BeebAsm is free software: you can redistribute it and/or modify it under the terms of the GNU
+  General Public License as published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
 
-	BeebAsm is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
-	even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+  BeebAsm is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+  even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License along with BeebAsm, as
-	COPYING.txt.  If not, see <http://www.gnu.org/licenses/>.
+  You should have received a copy of the GNU General Public License along with BeebAsm, as
+  COPYING.txt.  If not, see <http://www.gnu.org/licenses/>.
 */
 /*************************************************************************************************/
 
@@ -178,6 +178,7 @@ export class SymbolTable {
   Reset(): void {
     this._map.clear()
     this._labelScopes = 0
+    this._labelList = []
     this._scopeDetails = []
     this._references.clear()
     this.AddSymbol('PI', Math.PI, noLocation)
@@ -242,6 +243,8 @@ export class SymbolTable {
   }
 
   AddLabel(symbol: string): void {
+    // Note: this data is not used (beebasm uses it for dumping label list to file)
+    // Keeping around for now in case it's useful in debugging
     if (GlobalData.Instance.IsSecondPass()) {
       const addr = ObjectCode.Instance.GetPC()
       const identifier =
@@ -257,7 +260,6 @@ export class SymbolTable {
       }
       this._labelList.push(this._lastLabel)
     }
-    // TODO - check if can add symbol on second pass, currently getting deleted after first pass and not re-added
   }
 
   PushBrace(uri: string, startLine: number, forID: number): void {

--- a/src/server/completions.ts
+++ b/src/server/completions.ts
@@ -30,7 +30,7 @@ const commandCompletions: CompletionItem[] = beebasmCommands.map((item) => ({
   label: item.command,
   kind: CompletionItemKind.Method,
   insertTextFormat: InsertTextFormat.Snippet,
-  insertText: `${item.label} $0`,
+  insertText: `${item.command} $0`,
   command: triggerParameterHints,
   detail: 'command',
   documentation: item.documentation,

--- a/src/server/filehandler.ts
+++ b/src/server/filehandler.ts
@@ -11,6 +11,7 @@ export class FileHandler {
   private static _instance: FileHandler
   private _textDocuments: Map<string, { contents: string; modified: Date }> =
     new Map<string, { contents: string; modified: Date }>()
+  private includedToParentMap = new Map<string, string>()
   public documents: TextDocuments<TextDocument> = new TextDocuments(
     TextDocument,
   )
@@ -22,6 +23,27 @@ export class FileHandler {
   public static get Instance() {
     // Do you need arguments? Make it a regular static method instead.
     return this._instance || (this._instance = new this())
+  }
+
+  public GetTargetFileName(fileName: string): string | undefined {
+    // Recursively get the parent file name until
+    // the parent file name is the same as the file name
+    let targetFileName = this.includedToParentMap.get(fileName)
+    if (targetFileName === undefined) {
+      return undefined
+    }
+    while (targetFileName !== fileName) {
+      fileName = targetFileName
+      targetFileName = this.includedToParentMap.get(fileName)
+      if (targetFileName === undefined) {
+        return undefined // shouldn't end up here
+      }
+    }
+    return targetFileName
+  }
+
+  public SetTargetFileName(fileName: string, targetFileName: string): void {
+    this.includedToParentMap.set(fileName, targetFileName)
   }
 
   public Clear(): void {

--- a/src/server/hoverprovider.ts
+++ b/src/server/hoverprovider.ts
@@ -48,7 +48,7 @@ export class HoverProvider {
           // try to find in list of commands beebasmCommands
           // iterate through beebasmCommands looking for a match
           for (const cmd of beebasmCommands) {
-            if (cmd.label === command) {
+            if (cmd.command === command) {
               const mdText: MarkupContent = {
                 kind: 'markdown',
                 value: `## ${cmd.label}
@@ -133,12 +133,12 @@ ${this.getFlagsTable(info.flags)}`
    */
   private getFlagsTable(flags: string): string {
     /* Flag meanings:
-		-  Flag unaffected
-		*  Flag affected
-		0  Flag reset
-		1  Flag set
-		?  Unknown
-		Order: NV_BDIZC */
+    -  Flag unaffected
+    *  Flag affected
+    0  Flag reset
+    1  Flag set
+    ?  Unknown
+    Order: NV_BDIZC */
 
     if (flags.length === 0) {
       flags = '--------'

--- a/src/server/test/runTests.ts
+++ b/src/server/test/runTests.ts
@@ -6,7 +6,7 @@ const mocha = new Mocha({
 })
 mocha.timeout(100000)
 
-mocha.addFile('./server/out/test/tests.js')
+mocha.addFile('./out/server/test/tests.js')
 mocha.run((failures: number) => {
   if (failures > 0) {
     new Error(`${failures} tests failed.`)


### PR DESCRIPTION
Enables two consistency checks (for assembled code and label addresses) between the two parses. They had been disabled in development due to false positives but now working on all the test projects I tried. If assembled code gets inconsistent, it will probably stay inconsistent for all subsequent code, so we introduce a limit of one error of this type, especially as the first place it goes wrong will be the most interesting.