### PR TITLE
feat(emulator): Mute audio when emulator paused or no longer visible

### DIFF
--- a/src/scripts/custom-audio-handler.ts
+++ b/src/scripts/custom-audio-handler.ts
@@ -54,6 +54,10 @@ export class CustomAudioHandler extends AudioHandler {
     return this.audioContext && this.audioContext.state === 'running'
   }
 
+  isMuted(): boolean {
+    return this.muted$.value
+  }
+
   toggleMute(): boolean {
     if (this.muted$.value) {
       this.unmute()

--- a/src/scripts/custom-audio-handler.ts
+++ b/src/scripts/custom-audio-handler.ts
@@ -9,7 +9,7 @@ export class CustomAudioHandler extends AudioHandler {
   enabled$ = new BehaviorSubject<boolean>(false)
 
   constructor(
-    warningNode: JQuery<HTMLElement>,
+    public warningNode: JQuery<HTMLElement>,
     audioFilterFreq: number,
     audioFilterQ: number,
     noSeek: boolean,

--- a/src/scripts/emulator-toolbar.ts
+++ b/src/scripts/emulator-toolbar.ts
@@ -25,9 +25,8 @@ export class EmulatorToolBar {
     this.buttonExpand.on('click', () => this.onExpandClick())
 
     // listener for audio handler state changes
-    emulatorView.audioHandler.enabled$.subscribe((enabled) => {
-      this.buttonSound.prop('appearance', enabled ? 'secondary' : 'primary')
-      this.buttonSound.prop('disabled', !enabled)
+    emulatorView.audioHandler.enabled$.subscribe((_enabled) => {
+      this.updateSoundButton()
     })
     // listener for audio handler mute state changes
     emulatorView.audioHandler.muted$.subscribe((muted) => {
@@ -143,7 +142,12 @@ export class EmulatorToolBar {
       $('span:first', this.buttonControl).addClass('codicon-debug-start')
     }
     this.buttonRestart.prop('disabled', !isRunning)
+    this.buttonExpand.prop('disabled', !isRunning)
     this.buttonControl.prop('appearance', isRunning ? 'secondary' : 'primary')
+
+    // bit of a hack to disable the audio warning so we dont get mute state messed up if not running emulator
+    this.emulatorView.audioHandler.warningNode.prop('disabled', !isRunning)
+    this.updateSoundButton()
   }
 
   private onControlClick() {
@@ -171,5 +175,11 @@ export class EmulatorToolBar {
       this.emulatorView.toggleFullscreen()
       this.emulatorView.focusInput()
     }
+  }
+  private updateSoundButton() {
+    const audioEnabled = this.emulatorView.audioHandler.isEnabled()
+    const buttonEnabled = audioEnabled && this.emulatorView.emulatorRunning
+    this.buttonSound.prop('appearance', audioEnabled ? 'secondary' : 'primary')
+    this.buttonSound.prop('disabled', !buttonEnabled)
   }
 }

--- a/src/scripts/emulator-toolbar.ts
+++ b/src/scripts/emulator-toolbar.ts
@@ -76,7 +76,9 @@ export class EmulatorToolBar {
       this.onDiscChange(event),
     )
 
-    this.updateEmulatorStatus()
+    this.emulatorView.emulatorRunning$.subscribe((isRunning) =>
+      this.onEmulatorRunStateChange(isRunning),
+    )
   }
 
   private async onModelChange(event: JQuery.ChangeEvent) {
@@ -93,7 +95,6 @@ export class EmulatorToolBar {
     }
     console.log(JSON.stringify(model))
     await this.emulatorView.boot(model)
-    this.updateEmulatorStatus()
     this.emulatorView.focusInput()
     // notifyHost({
     //   command: ClientCommand.Info,
@@ -133,8 +134,7 @@ export class EmulatorToolBar {
     this.discSelector.val(`${discImage.url}|${discImage.name}`)
   }
 
-  private updateEmulatorStatus() {
-    const isRunning = this.emulatorView.emulator?.running
+  private onEmulatorRunStateChange(isRunning: boolean) {
     if (isRunning) {
       $('span:first', this.buttonControl).removeClass('codicon-debug-start')
       $('span:first', this.buttonControl).addClass('codicon-debug-pause')
@@ -148,13 +148,12 @@ export class EmulatorToolBar {
 
   private onControlClick() {
     const emulator = this.emulatorView.emulator
-    if (emulator?.running) {
+    if (emulator?.emulatorRunning) {
       emulator.pause()
     } else {
-      emulator?.start()
+      emulator?.resume()
       this.emulatorView.focusInput()
     }
-    this.updateEmulatorStatus()
   }
   private async onRestartClick() {
     if (this.buttonRestart) {

--- a/src/scripts/emulator-view.ts
+++ b/src/scripts/emulator-view.ts
@@ -41,6 +41,9 @@ export class EmulatorView {
   // shared emulator state observable
   private _emulatorRunning$ = new BehaviorSubject<boolean>(false)
   emulatorRunning$ = this._emulatorRunning$.pipe(distinctUntilChanged())
+  get emulatorRunning(): boolean {
+    return this._emulatorRunning$.value
+  }
 
   // currently selected disc image
   private _discImageFile$ = new BehaviorSubject<DiscImageFile>(NO_DISC)
@@ -189,17 +192,12 @@ export class EmulatorView {
     await this.mountDisc(this.discImageFile)
   }
 
-  private isMutedWhenSuspended: boolean = false
   suspend() {
-    this.isMutedWhenSuspended = this.audioHandler.isMuted()
-    if (!this.isMutedWhenSuspended) {
-      this.audioHandler.mute()
-    }
+    this.emulator?.pause()
   }
 
   resume() {
-    if (!this.isMutedWhenSuspended) {
-      this.audioHandler.unmute()
-    }
+    // dont auto resume, make user do this
+    // this.emulator?.resume()
   }
 }

--- a/src/scripts/emulator-view.ts
+++ b/src/scripts/emulator-view.ts
@@ -32,6 +32,8 @@ export class EmulatorView {
   model: Model | undefined
   emulator: Emulator | undefined // Dont hold references to the emulator, it may be paused and destroyed
 
+  private suspended: boolean = false
+
   // shared emulator update observable
   private _emulatorUpdate$ = new Subject<Emulator>()
   get emulatorUpdate$(): Observable<Emulator> {
@@ -185,5 +187,19 @@ export class EmulatorView {
   async reboot(hard: boolean = false) {
     this.emulator?.resetCpu(hard)
     await this.mountDisc(this.discImageFile)
+  }
+
+  private isMutedWhenSuspended: boolean = false
+  suspend() {
+    this.isMutedWhenSuspended = this.audioHandler.isMuted()
+    if (!this.isMutedWhenSuspended) {
+      this.audioHandler.mute()
+    }
+  }
+
+  resume() {
+    if (!this.isMutedWhenSuspended) {
+      this.audioHandler.unmute()
+    }
   }
 }

--- a/src/scripts/emulator.ts
+++ b/src/scripts/emulator.ts
@@ -76,7 +76,6 @@ export class Emulator {
   ready: boolean
   lastFrameTime: number
   onAnimFrame: FrameRequestCallback
-  // running: boolean = false
   lastShiftLocation: number
   lastAltLocation: number
   lastCtrlLocation: number
@@ -169,12 +168,22 @@ export class Emulator {
   // 	modelName += ' | GXR';
   // }
 
+  private isMutedWhenSuspended: boolean = false
+
   pause() {
     this._emulatorRunning$.next(false)
+    this.isMutedWhenSuspended = this.audioHandler.isMuted()
+    if (!this.isMutedWhenSuspended) {
+      this.audioHandler.mute()
+    }
   }
 
   resume() {
     if (this.emulatorRunning) return
+    if (!this.isMutedWhenSuspended) {
+      this.audioHandler.unmute()
+    }
+
     this._emulatorRunning$.next(true)
     window.requestAnimationFrame(this.onAnimFrame)
   }

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -69,6 +69,11 @@ window.addEventListener('message', (event) => {
       // We handle focus via window events at the moment
       // since these can arrive before the webview is ready
       // but we may want to do something with visibility or active state later
+      if (message.focus.visible) {
+        emulatorView.resume()
+      } else {
+        emulatorView.suspend()
+      }
       break
     case HostCommand.DiscImages:
       emulatorView.setDiscImages(message.discImages)


### PR DESCRIPTION
Audio state - enabled && || mute are a bit tricky to state manage, but this PR sorts it.
We now listen for panel visibility events and pause/resume the emulator accordingly.
Pausing the emulator now mutes the audio, if it is enabled.
Emulator requires user to restart it when visibility changes.