### PR TITLE
fix(development): Set outfiles in launch task

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,8 +7,13 @@
 			"type": "extensionHost",
 			"request": "launch",
 			"runtimeExecutable": "${execPath}",
-			"args": ["--extensionDevelopmentPath=${workspaceRoot}"],
-			// "outFiles": ["${workspaceRoot}/out/main.js", "${workspaceRoot}/out/server.js"],
+			"args": [
+				"--extensionDevelopmentPath=${workspaceRoot}"
+			],
+			"outFiles": [
+				"${workspaceRoot}/dist/main.js",
+				"${workspaceRoot}/dist/server.js"
+			],
 			"sourceMaps": true,
 			"autoAttachChildProcesses": true,
 			"preLaunchTask": {


### PR DESCRIPTION
I noticed that breakpoints couldn't be set from the typescript files for the server process and was having to set breakpoints in the bundled server.js instead. Turns out to be a trivial fix to the launch.json task to set the outFiles to the new `dist` path.