### PR TITLE
feat(development): Add sample E2E tests and launch.json config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,5 +21,19 @@
 				"script": "build"
 			}
 		},
+		{
+			"name": "Language Server E2E Test",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceRoot}",
+				"--extensionTestsPath=${workspaceRoot}/out/client/test/index",
+				"${workspaceRoot}/src/client/test/testFixture"
+			],
+			"outFiles": [
+				"${workspaceRoot}/out/client/test/**/*.js"
+			]
+		}
 	]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beeb-vsc",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "beeb-vsc",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -42,6 +42,7 @@
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
         "eslint-plugin-unused-imports": "^3.1.0",
+        "glob": "^10.3.12",
         "minimist": "^1.2.8",
         "mocha": "^10.2.0",
         "npm-run-all": "^4.1.5",
@@ -3684,19 +3685,22 @@
       "optional": true
     },
     "node_modules/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "version": "10.3.12",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.12.tgz",
+      "integrity": "sha512-TCNv8vJ+xz4QiqTpfOJA7HvYv+tNIRHKfUWw/q+v2jdgN4ebz+KY9tGx5J4rHP0o84mNP+ApH66HRX8us3Khqg==",
       "dev": true,
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.3.6",
+        "minimatch": "^9.0.1",
+        "minipass": "^7.0.4",
+        "path-scurry": "^1.10.2"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -3719,18 +3723,6 @@
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "peer": true
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/globals": {
       "version": "13.24.0",
@@ -4990,6 +4982,25 @@
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/mocha/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/mocha/node_modules/minimatch": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
@@ -5673,12 +5684,12 @@
       "dev": true
     },
     "node_modules/path-scurry": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
-      "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.2.tgz",
+      "integrity": "sha512-7xTavNy5RQXnsjANvVvMkEjvloOinkAjv/Z6Ildz9v2RinZ4SBKTWFOVRbaF8p0vpHnyjV/UwNDdKuUv6M5qcA==",
       "dev": true,
       "dependencies": {
-        "lru-cache": "^9.1.1 || ^10.0.0",
+        "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "engines": {
@@ -6495,28 +6506,6 @@
       },
       "engines": {
         "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/glob": {
-      "version": "10.3.10",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
-      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
-      "dev": true,
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^2.3.5",
-        "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-        "path-scurry": "^1.10.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -10679,27 +10668,16 @@
       "optional": true
     },
     "glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "version": "10.3.12",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.12.tgz",
+      "integrity": "sha512-TCNv8vJ+xz4QiqTpfOJA7HvYv+tNIRHKfUWw/q+v2jdgN4ebz+KY9tGx5J4rHP0o84mNP+ApH66HRX8us3Khqg==",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
-      },
-      "dependencies": {
-        "minimatch": {
-          "version": "5.1.6",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
-        }
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.3.6",
+        "minimatch": "^9.0.1",
+        "minipass": "^7.0.4",
+        "path-scurry": "^1.10.2"
       }
     },
     "glob-parent": {
@@ -11641,6 +11619,19 @@
         "yargs-unparser": "2.0.0"
       },
       "dependencies": {
+        "glob": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+          "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
+        },
         "minimatch": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
@@ -12169,12 +12160,12 @@
       "dev": true
     },
     "path-scurry": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
-      "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.2.tgz",
+      "integrity": "sha512-7xTavNy5RQXnsjANvVvMkEjvloOinkAjv/Z6Ildz9v2RinZ4SBKTWFOVRbaF8p0vpHnyjV/UwNDdKuUv6M5qcA==",
       "dev": true,
       "requires": {
-        "lru-cache": "^9.1.1 || ^10.0.0",
+        "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "dependencies": {
@@ -12694,21 +12685,6 @@
       "dev": true,
       "requires": {
         "glob": "^10.3.7"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "10.3.10",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
-          "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
-          "dev": true,
-          "requires": {
-            "foreground-child": "^3.1.0",
-            "jackspeak": "^2.3.5",
-            "minimatch": "^9.0.1",
-            "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-            "path-scurry": "^1.10.1"
-          }
-        }
       }
     },
     "run-parallel": {

--- a/package.json
+++ b/package.json
@@ -208,6 +208,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-unused-imports": "^3.1.0",
+    "glob": "^10.3.12",
     "minimist": "^1.2.8",
     "mocha": "^10.2.0",
     "npm-run-all": "^4.1.5",

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -266,16 +266,22 @@ function checkSourceFilesSpecified() {
       settingsObject = JSON.parse(fs.readFileSync(settingsPath, 'utf8'))
     } catch (err) {
       settingsIssue = true
+      console.log('Error reading ' + settingsPath + ' ' + err)
     }
     if (settingsObject.beebvsc === undefined) {
       settingsIssue = true
+      console.log('Error with settingsObject.beebvsc === undefined')
     } else {
       if (settingsObject.beebvsc?.sourceFile === undefined) {
         settingsIssue = true
+        console.log(
+          'Error with settingsObject.beebvsc?.sourceFile === undefined',
+        )
       }
     }
   } else {
     settingsIssue = true
+    console.log('Error with settingsPath not existing ' + settingsPath)
   }
   if (settingsIssue) {
     window.showErrorMessage(

--- a/src/client/test/completion.test.ts
+++ b/src/client/test/completion.test.ts
@@ -1,0 +1,47 @@
+import {
+  CompletionItemKind,
+  Uri,
+  Position,
+  CompletionList,
+  commands,
+} from 'vscode'
+import * as assert from 'assert'
+import { getDocUri, activate } from './helper'
+
+suite('Should do completion', () => {
+  const docUri = getDocUri('completion.6502')
+
+  test('Completes BeebASM keywords', async () => {
+    await testCompletion(docUri, new Position(0, 0), {
+      items: [
+        { label: 'PRINT', kind: CompletionItemKind.Method },
+        { label: 'STRING$', kind: CompletionItemKind.Function },
+      ],
+    })
+  })
+})
+
+async function testCompletion(
+  docUri: Uri,
+  position: Position,
+  expectedCompletionList: CompletionList,
+) {
+  await activate(docUri)
+
+  // Executing the command `vscode.executeCompletionItemProvider` to simulate triggering completion
+  const actualCompletionList = (await commands.executeCommand(
+    'vscode.executeCompletionItemProvider',
+    docUri,
+    position,
+  )) as CompletionList
+
+  assert.ok(actualCompletionList.items.length >= 2)
+  // check list contains each of the expected items
+  expectedCompletionList.items.forEach((expectedItem, _i) => {
+    assert.ok(
+      actualCompletionList.items.some(
+        (item) => item.label === expectedItem.label,
+      ),
+    )
+  })
+}

--- a/src/client/test/diagnostics.test.ts
+++ b/src/client/test/diagnostics.test.ts
@@ -1,0 +1,60 @@
+import {
+  DiagnosticSeverity,
+  Position,
+  Uri,
+  Range,
+  Diagnostic,
+  languages,
+} from 'vscode'
+import * as assert from 'assert'
+import { getDocUri, activate } from './helper'
+
+suite('Should get diagnostics', () => {
+  const docUri = getDocUri('diagnostics.6502')
+
+  test('Common diagnostics', async () => {
+    await testDiagnostics(docUri, [
+      {
+        message: 'Symbol not defined.',
+        range: toRange(0, 0, 0, 11),
+        severity: DiagnosticSeverity.Warning,
+        source: 'vscode-beebasm',
+      },
+      {
+        message: 'Immediate value too large.',
+        range: toRange(1, 0, 1, 8),
+        severity: DiagnosticSeverity.Warning,
+        source: 'vscode-beebasm',
+      },
+      {
+        message: 'Mismatched parentheses.',
+        range: toRange(2, 0, 2, 7),
+        severity: DiagnosticSeverity.Warning,
+        source: 'vscode-beebasm',
+      },
+    ])
+  })
+})
+
+function toRange(sLine: number, sChar: number, eLine: number, eChar: number) {
+  const start = new Position(sLine, sChar)
+  const end = new Position(eLine, eChar)
+  return new Range(start, end)
+}
+
+async function testDiagnostics(docUri: Uri, expectedDiagnostics: Diagnostic[]) {
+  await activate(docUri)
+
+  const actualDiagnostics = languages.getDiagnostics(docUri).sort((a, b) => {
+    return a.range.start.compareTo(b.range.start)
+  })
+
+  assert.equal(actualDiagnostics.length, expectedDiagnostics.length)
+
+  expectedDiagnostics.forEach((expectedDiagnostic, i) => {
+    const actualDiagnostic = actualDiagnostics[i]
+    assert.equal(actualDiagnostic.message, expectedDiagnostic.message)
+    assert.deepEqual(actualDiagnostic.range, expectedDiagnostic.range)
+    assert.equal(actualDiagnostic.severity, expectedDiagnostic.severity)
+  })
+}

--- a/src/client/test/helper.ts
+++ b/src/client/test/helper.ts
@@ -1,0 +1,42 @@
+import {
+  TextDocument,
+  TextEditor,
+  Uri,
+  extensions,
+  workspace,
+  window,
+  Range,
+} from 'vscode'
+import * as path from 'path'
+
+export let doc: TextDocument
+export let editor: TextEditor
+
+export async function activate(docUri: Uri) {
+  // The extensionId is `publisher.name` from package.json
+  const ext = extensions.getExtension('simondotm.beeb-vsc')!
+  await ext.activate()
+  try {
+    doc = await workspace.openTextDocument(docUri)
+    editor = await window.showTextDocument(doc)
+    await sleep(2000) // Wait for server activation
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+async function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export const getDocPath = (p: string) => {
+  return path.resolve(__dirname, '../../../src/client/test/testFixture', p)
+}
+export const getDocUri = (p: string) => {
+  return Uri.file(getDocPath(p))
+}
+
+export async function setTestContent(content: string): Promise<boolean> {
+  const all = new Range(doc.positionAt(0), doc.positionAt(doc.getText().length))
+  return editor.edit((eb) => eb.replace(all, content))
+}

--- a/src/client/test/index.ts
+++ b/src/client/test/index.ts
@@ -1,0 +1,36 @@
+import * as path from 'path'
+import Mocha from 'mocha'
+import { glob } from 'glob'
+
+export function run(): Promise<void> {
+  // Create the mocha test
+  const mocha = new Mocha({
+    ui: 'tdd',
+    color: true,
+  })
+  mocha.timeout(100000)
+
+  const testsRoot = __dirname
+
+  return new Promise((resolve, reject) => {
+    // iterate overall all *.test.js files in the test directory
+    // then add to the test suite then run the test
+    glob('**.test.js', { cwd: testsRoot }).then((files) => {
+      files.forEach((f) => mocha.addFile(path.resolve(testsRoot, f)))
+
+      try {
+        // Run the mocha test
+        mocha.run((failures) => {
+          if (failures > 0) {
+            reject(new Error(`${failures} tests failed.`))
+          } else {
+            resolve()
+          }
+        })
+      } catch (err) {
+        console.error(err)
+        reject(err)
+      }
+    })
+  })
+}

--- a/src/client/test/runTest.ts
+++ b/src/client/test/runTest.ts
@@ -1,0 +1,23 @@
+import * as path from 'path'
+
+import { runTests } from '@vscode/test-electron'
+
+async function main() {
+  try {
+    // The folder containing the Extension Manifest package.json
+    // Passed to `--extensionDevelopmentPath`
+    const extensionDevelopmentPath = path.resolve(__dirname, '../../../')
+
+    // The path to test runner
+    // Passed to --extensionTestsPath
+    const extensionTestsPath = path.resolve(__dirname, './index')
+
+    // Download VS Code, unzip it and run the integration test
+    await runTests({ extensionDevelopmentPath, extensionTestsPath })
+  } catch (err) {
+    console.error('Failed to run tests')
+    process.exit(1)
+  }
+}
+
+main()

--- a/src/client/test/testFixture/.vscode/settings.json
+++ b/src/client/test/testFixture/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+	"beebvsc": {
+		"sourceFile": "/Users/tomtom/Documents/Beeb/VSCode/github-fork/beeb-vsc/src/client/test/testFixture/main.6502",
+		"targetName": "main.ssd"
+	}
+}

--- a/src/client/test/testFixture/diagnostics.6502
+++ b/src/client/test/testFixture/diagnostics.6502
@@ -1,0 +1,3 @@
+JSR missing
+CMP #999
+a = (10

--- a/src/client/test/testFixture/main.6502
+++ b/src/client/test/testFixture/main.6502
@@ -1,0 +1,5 @@
+; List of all the files to include in the build
+; i.e. all the files that need to be parsed for the test suite
+
+INCLUDE "completion.6502"
+INCLUDE "diagnostics.6502"


### PR DESCRIPTION
Adds the ability to create end-to-end tests which launch a host extension and run tests in place. Currently added a small number of tests for completions and diagnostics but can greatly expand this over time to provide good coverage of the language server features. 

- There is a new launch task, so from the 'Run and Debug' panel of VSCode can select 'Language Server E2E Test' to trigger the process. 
- New test suites can be added by creating new files in the src/client/test folder named with format **.test.ts
- Uses a test project created in src/client/test/testFixture folder, can add new files as necessary but all should be added to main.6502 as INCLUDE statements
- Currently would require editing the settings.json file within the src/client/test/testFixture/.vscode folder for every development copy, pending #107 allowing relative paths for the compile target