### PR TITLE
feat: File handling improvements

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,8 +32,11 @@
 				"${workspaceRoot}/src/client/test/testFixture"
 			],
 			"outFiles": [
-				"${workspaceRoot}/out/client/test/**/*.js"
-			]
+				"${workspaceRoot}/dist/main.js",
+				"${workspaceRoot}/dist/server.js"
+			],
+			"sourceMaps": true,
+			"autoAttachChildProcesses": true,
 		}
 	]
 }

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -416,7 +416,10 @@ function createTargetCommand(): void {
 
   // Create list of files in the root folder with the supported file extensions
   const rootPath = getWorkspacePath()
-  let targetList = fs.readdirSync(rootPath)
+  let targetList = fs.readdirSync(rootPath, {
+    encoding: 'utf-8',
+    recursive: true,
+  })
   targetList = targetList.filter((file) =>
     supportedFileTypes.includes(file.split('.').pop()!),
   )

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -330,7 +330,7 @@ function CreateNewLocalSettingsJson(sourceFile: string, targetName: string) {
   // this will be used to store local settings for the current workspace
   // (eg. assembler/emulator paths)
   const settingsPath = path.join(getWorkspacePath(), '.vscode', 'settings.json')
-  const sourcePath = path.join(getWorkspacePath(), sourceFile)
+  const sourcePath = sourceFile
 
   const settingsObject: BeebVSCSettings = {
     beebvsc: {
@@ -454,7 +454,7 @@ function createTargetCommand(): void {
     // get the tasks array, we will add out new target here
     const tasks = tasksObject.tasks
 
-    // Check if this target is already present, we don't hanlde this presently
+    // Check if this target is already present, we don't handle this presently
     // TODO: offer option to replace
     for (let i = 0; i < tasks.length; i++) {
       if (target.toLowerCase() === tasks[i].label.toLowerCase()) {
@@ -598,8 +598,11 @@ function SaveJSONFiles(
     } else {
       newSourceFile = []
     }
-    if (!newSourceFile.includes(path.join(rootPath, selection))) {
-      newSourceFile.push(path.join(rootPath, selection))
+    if (
+      !newSourceFile.includes(path.join(rootPath, selection)) && // legacy check for full path
+      !newSourceFile.includes(selection)
+    ) {
+      newSourceFile.push(selection)
     }
     settingsObject.beebvsc = {
       sourceFile: newSourceFile,

--- a/src/client/test/testFixture/.vscode/settings.json
+++ b/src/client/test/testFixture/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
 	"beebvsc": {
-		"sourceFile": "/Users/tomtom/Documents/Beeb/VSCode/github-fork/beeb-vsc/src/client/test/testFixture/main.6502",
+		"sourceFile": "main.6502",
 		"targetName": "main.ssd"
 	}
 }

--- a/src/server/beebasm-ts/lineparser.ts
+++ b/src/server/beebasm-ts/lineparser.ts
@@ -32,9 +32,8 @@ import { MacroTable } from './macro'
 import * as AsmException from './asmexception'
 import { strftime } from '../strftime-master/strftime'
 import { AST, ASTType } from '../ast'
-import { FileHandler } from '../filehandler'
-import * as path from 'path'
-import { URI } from 'vscode-uri'
+import { FileHandler, URItoReference, URItoVSCodeURI } from '../filehandler'
+import path from 'path'
 // import exp = require('constants');
 // import { match } from 'assert';
 
@@ -3726,21 +3725,8 @@ export class LineParser {
       throw new AsmException.SyntaxError_CantInclude(this._line, this._column)
     }
     const filename = this.EvaluateExpressionAsString().replace(/\\/g, '/')
-    let fspath: string
-    if (process.platform === 'win32') {
-      fspath = URI.parse('file:///' + path.resolve(filename)).fsPath
-    } else {
-      fspath = URI.parse(path.resolve(filename)).fsPath
-    }
-    let includeFile: string
-    if (process.platform === 'win32') {
-      includeFile = URI.parse('file:///' + path.resolve(filename)).toString()
-      // if (includeFile.endsWith('/')) {
-      // 	includeFile = includeFile.substring(0, includeFile.length - 1);
-      // }
-    } else {
-      includeFile = fspath
-    }
+    const fspath = URItoVSCodeURI(path.resolve(filename))
+    const includeFile: string = URItoReference(fspath)
     if (
       this._ASTValueStack[0].type === ASTType.Value &&
       this._ASTValueStack[0].value === '"' + filename + '"'
@@ -4200,15 +4186,7 @@ export class LineParser {
     ) {
       const startColumn = this._ASTValueStack[0].startColumn + 1
       const endColumn = startColumn + hostFilename.length
-      let filelink: string
-      if (process.platform === 'win32') {
-        filelink = URI.parse('file:///' + path.resolve(hostFilename)).toString()
-        if (filelink.endsWith('/')) {
-          filelink = filelink.substring(0, filelink.length - 1)
-        }
-      } else {
-        filelink = URI.parse(path.resolve(hostFilename)).fsPath
-      }
+      const filelink = URItoVSCodeURI(path.resolve(hostFilename))
       const link: DocumentLink = {
         range: {
           start: { line: this._lineno, character: startColumn },
@@ -4240,15 +4218,7 @@ export class LineParser {
     ) {
       const startColumn = this._ASTValueStack[0].startColumn + 1
       const endColumn = startColumn + hostFilename.length
-      let filelink: string
-      if (process.platform === 'win32') {
-        filelink = URI.parse('file:///' + path.resolve(hostFilename)).toString()
-        if (filelink.endsWith('/')) {
-          filelink = filelink.substring(0, filelink.length - 1)
-        }
-      } else {
-        filelink = URI.parse(path.resolve(hostFilename)).fsPath
-      }
+      const filelink = URItoVSCodeURI(path.resolve(hostFilename))
       const link: DocumentLink = {
         range: {
           start: { line: this._lineno, character: startColumn },

--- a/src/server/beebasm-ts/sourcecode.ts
+++ b/src/server/beebasm-ts/sourcecode.ts
@@ -102,7 +102,7 @@ export class SourceCode {
     this._lineNumber = lineNumber
     this._parent = parent
     this._lineStartPointer = 0
-    this._lines = contents.split('\n')
+    this._lines = contents.split(/\r\n|\n/g)
     this._diagnostics = diagnostics
     if (this._diagnostics.get(uri) === undefined) {
       this._diagnostics.set(uri, [])

--- a/src/server/beebasm-ts/sourcecode.ts
+++ b/src/server/beebasm-ts/sourcecode.ts
@@ -35,7 +35,6 @@ import {
 } from 'vscode-languageserver'
 import { integer } from 'vscode-languageserver'
 import { AST } from '../ast'
-import { URI } from 'vscode-uri'
 import path = require('path')
 
 const MAX_FOR_LEVELS = 256
@@ -277,10 +276,7 @@ export class SourceCode {
   }
 
   GetURI(): string {
-    let uri = this._uri
-    if (process.platform === 'win32') {
-      uri = URI.parse('file:///' + path.resolve(this._uri)).toString()
-    }
+    const uri = this._uri
     return uri
   }
 

--- a/src/server/beebasm-ts/symboltable.ts
+++ b/src/server/beebasm-ts/symboltable.ts
@@ -23,7 +23,6 @@
 import { integer, Location } from 'vscode-languageserver'
 import { GlobalData } from './globaldata'
 import { ObjectCode } from './objectcode'
-import { URI } from 'vscode-uri'
 
 // can't use Symbol as a type name because it's a reserved word
 export class SymbolData {
@@ -106,7 +105,7 @@ export class SymbolTable {
   // Get all symbols in scope for a particular location
   GetSymbolsByLocation(uri: string, line: number): Map<string, SymbolData> {
     const symbols = new Map<string, SymbolData>()
-    const uriSanitised = URI.parse(uri).fsPath
+    const uriSanitised = uri
     for (const [name, symbolData] of this._map.entries()) {
       if (!name.includes('@')) {
         // global symbols always included

--- a/src/server/filehandler.ts
+++ b/src/server/filehandler.ts
@@ -1,12 +1,10 @@
-// import { readFile, stat } from 'fs/promises';
 import { TextDocuments } from 'vscode-languageserver/node'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { readFileSync, statSync } from 'fs'
 import { URI } from 'vscode-uri'
 
-// Users should always check the TextDocuments collection before using this class
-// to avoid trying to access a file owned by the client
-
+// The TextDocuments collection is the files managed by vscode
+// For any included files, we manage with the _textDocuments map
 export class FileHandler {
   private static _instance: FileHandler
   private _textDocuments: Map<string, { contents: string; modified: Date }> =
@@ -57,7 +55,8 @@ export class FileHandler {
   public ReadTextFromFile(uri: string): string {
     if (this._textDocuments.has(uri)) {
       if (
-        this._textDocuments.get(uri)!.modified == this.GetFileModifiedTime(uri)
+        this._textDocuments.get(uri)!.modified.getTime() ==
+        this.GetFileModifiedTime(uri).getTime()
       ) {
         return this._textDocuments.get(uri)!.contents
       }
@@ -86,14 +85,10 @@ export class FileHandler {
 
   public GetDocumentText(uri: string): string {
     const cleanPath = URI.parse(uri).fsPath
-    const documentsText = this.GetFromDocumentsWithFSPath(cleanPath) // revert if not helping?
+    const documentsText = this.GetFromDocumentsWithFSPath(cleanPath)
     if (documentsText !== '') {
       return documentsText
     }
-    // const textDocument = this.documents.get(uri);
-    // if (textDocument) {
-    // 	return textDocument.getText();
-    // }
     // not managed by vscode so read from file directly
     const text = this.ReadTextFromFile(uri)
     return text
@@ -103,7 +98,6 @@ export class FileHandler {
     // iterate through documents, convert document uri to fsPath and compare to uri
     let docText: string | undefined
     this.documents.keys().forEach((key) => {
-      //const document = this.documents.get(key);
       if (URI.parse(key).fsPath === uri) {
         const document = this.documents.get(key)!
         docText = document.getText()

--- a/src/server/filehandler.ts
+++ b/src/server/filehandler.ts
@@ -79,7 +79,7 @@ export class FileHandler {
       })
       return fileContents
     } catch (error) {
-      throw new Error(`Unable to read file ${uri} with error ${error}`)
+      throw new Error(`Unable to read file ${uriPath} with error ${error}`)
     }
   }
 
@@ -128,21 +128,10 @@ export class FileHandler {
 
 // Tries to replicate format provided by params passed from vscode
 export function URItoVSCodeURI(uri: string): string {
+  if (URI.parse(uri).scheme === 'file') {
+    return URI.parse(uri).toString()
+  }
   return URI.parse(uri).toString()
-  // let fsPath: string
-  // try {
-  //   if (process.platform === 'win32' && !uri.startsWith('file:/')) {
-  //     const unixStyle = uri.replace(/\\/g, '/')
-  //     // console.log('unixStyle ' + unixStyle)
-  //     fsPath = URI.parse('file:///' + unixStyle).fsPath
-  //   } else {
-  //     fsPath = URI.parse(uri).fsPath
-  //   }
-  // } catch (error) {
-  //   console.log(`Error converting URI ${uri} to path: ${error}`)
-  //   return ''
-  // }
-  // return fsPath
 }
 
 export function URItoReference(uri: string): string {

--- a/src/server/filehandler.ts
+++ b/src/server/filehandler.ts
@@ -131,7 +131,7 @@ export function URItoVSCodeURI(uri: string): string {
   if (URI.parse(uri).scheme === 'file') {
     return URI.parse(uri).toString()
   }
-  return URI.parse(uri).toString()
+  return URI.file(uri).toString()
 }
 
 export function URItoReference(uri: string): string {

--- a/src/server/filehandler.ts
+++ b/src/server/filehandler.ts
@@ -1,4 +1,4 @@
-import { TextDocuments } from 'vscode-languageserver/node'
+import { TextDocuments, Files } from 'vscode-languageserver/node'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { readFileSync, statSync } from 'fs'
 import { URI } from 'vscode-uri'
@@ -13,6 +13,7 @@ export class FileHandler {
   public documents: TextDocuments<TextDocument> = new TextDocuments(
     TextDocument,
   )
+  private workspaceRoot: string | undefined
 
   private constructor() {
     //TBD
@@ -41,7 +42,7 @@ export class FileHandler {
   }
 
   public SetTargetFileName(fileName: string, targetFileName: string): void {
-    this.includedToParentMap.set(URItoPath(fileName), URItoPath(targetFileName))
+    this.includedToParentMap.set(fileName, targetFileName)
   }
 
   public Clear(): void {
@@ -53,18 +54,24 @@ export class FileHandler {
   }
 
   public ReadTextFromFile(uri: string): string {
+    const uriPath = Files.uriToFilePath(uri) ?? ''
     if (this._textDocuments.has(uri)) {
       if (
         this._textDocuments.get(uri)!.modified.getTime() ==
-        this.GetFileModifiedTime(uri).getTime()
+        this.GetFileModifiedTime(uriPath).getTime()
       ) {
         return this._textDocuments.get(uri)!.contents
       }
     }
 
     try {
-      const fileContents = readFileSync(uri, { encoding: 'utf8' })
-      const timestamp = this.GetFileModifiedTime(uri)
+      if (uriPath === '') {
+        throw new Error(
+          `Unable to read file ${uri} - could not convert to path`,
+        )
+      }
+      const fileContents = readFileSync(uriPath, { encoding: 'utf8' })
+      const timestamp = this.GetFileModifiedTime(uriPath)
 
       this._textDocuments.set(uri, {
         contents: fileContents,
@@ -72,9 +79,7 @@ export class FileHandler {
       })
       return fileContents
     } catch (error) {
-      throw new Error(
-        `Unable to read file ${uri.toString()} with error ${error}`,
-      )
+      throw new Error(`Unable to read file ${uri} with error ${error}`)
     }
   }
 
@@ -84,7 +89,10 @@ export class FileHandler {
   }
 
   public GetDocumentText(uri: string): string {
-    const cleanPath = URI.parse(uri).fsPath
+    const cleanPath = uri //Files.uriToFilePath(uri)
+    if (cleanPath === undefined) {
+      return ''
+    }
     const documentsText = this.GetFromDocumentsWithFSPath(cleanPath)
     if (documentsText !== '') {
       return documentsText
@@ -98,7 +106,7 @@ export class FileHandler {
     // iterate through documents, convert document uri to fsPath and compare to uri
     let docText: string | undefined
     this.documents.keys().forEach((key) => {
-      if (URI.parse(key).fsPath === uri) {
+      if (key === uri) {
         const document = this.documents.get(key)!
         docText = document.getText()
       }
@@ -108,21 +116,36 @@ export class FileHandler {
     }
     return ''
   }
+
+  public GetWorkspaceRoot(): string | undefined {
+    return this.workspaceRoot
+  }
+
+  public SetWorkspaceRoot(root: string): void {
+    this.workspaceRoot = root
+  }
 }
 
-export function URItoPath(uri: string): string {
-  let fsPath: string
-  try {
-    if (process.platform === 'win32' && !uri.startsWith('file:/')) {
-      const unixStyle = uri.replace(/\\/g, '/')
-      // console.log('unixStyle ' + unixStyle)
-      fsPath = URI.parse('file:///' + unixStyle).fsPath
-    } else {
-      fsPath = URI.parse(uri).fsPath
-    }
-  } catch (error) {
-    console.log(`Error converting URI ${uri} to path: ${error}`)
-    return ''
-  }
-  return fsPath
+// Tries to replicate format provided by params passed from vscode
+export function URItoVSCodeURI(uri: string): string {
+  return URI.parse(uri).toString()
+  // let fsPath: string
+  // try {
+  //   if (process.platform === 'win32' && !uri.startsWith('file:/')) {
+  //     const unixStyle = uri.replace(/\\/g, '/')
+  //     // console.log('unixStyle ' + unixStyle)
+  //     fsPath = URI.parse('file:///' + unixStyle).fsPath
+  //   } else {
+  //     fsPath = URI.parse(uri).fsPath
+  //   }
+  // } catch (error) {
+  //   console.log(`Error converting URI ${uri} to path: ${error}`)
+  //   return ''
+  // }
+  // return fsPath
+}
+
+export function URItoReference(uri: string): string {
+  // puts in format for passing back to client
+  return URI.parse(uri).toString()
 }

--- a/src/server/hoverprovider.ts
+++ b/src/server/hoverprovider.ts
@@ -13,7 +13,6 @@ import {
   beebasmCommands,
   beebasmFunctions,
 } from './shareddata'
-import { URI } from 'vscode-uri'
 import { SymbolTable } from './beebasm-ts/symboltable'
 import { FileHandler } from './filehandler'
 import { MacroTable } from './beebasm-ts/macro'
@@ -26,8 +25,8 @@ export class HoverProvider {
   }
 
   onHover(params: HoverParams): Hover | null {
-    const fspath = URI.parse(params.textDocument.uri).fsPath
-    const docTrees = this.trees.get(fspath)
+    const uri = params.textDocument.uri
+    const docTrees = this.trees.get(uri)
     const location = params.position
     if (docTrees !== undefined) {
       const lineTree = docTrees[location.line]
@@ -87,7 +86,7 @@ Return: ${cmd.return}`,
         if (symbol !== '') {
           const [defn, _] = SymbolTable.Instance.GetSymbolByLine(
             symbol,
-            fspath,
+            uri,
             location.line,
           )
           if (defn === undefined) {
@@ -97,9 +96,7 @@ Return: ${cmd.return}`,
           if (loc.uri === '') {
             return null // Built in constant - could have special info here documenting P%, CPU etc.
           }
-          const document = FileHandler.Instance.GetDocumentText(
-            URI.parse(loc.uri).fsPath,
-          )
+          const document = FileHandler.Instance.GetDocumentText(loc.uri)
           if (document === undefined) {
             return null
           }

--- a/src/server/semantictokenprovider.ts
+++ b/src/server/semantictokenprovider.ts
@@ -1,6 +1,6 @@
 import { SemanticTokensParams } from 'vscode-languageserver'
 import { AST, GetSemanticTokens } from './ast'
-import { URItoPath } from './filehandler'
+import { URItoVSCodeURI } from './filehandler'
 
 export class SemanticTokensProvider {
   private trees: Map<string, AST[]>
@@ -10,7 +10,7 @@ export class SemanticTokensProvider {
   }
 
   on(params: SemanticTokensParams): { data: number[] } {
-    const doc = URItoPath(params.textDocument.uri)
+    const doc = URItoVSCodeURI(params.textDocument.uri)
     const asts = this.trees.get(doc)
     if (asts === undefined) {
       return { data: [] }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -7,6 +7,7 @@ import {
   InitializeResult,
   ConfigurationItem,
   DocumentLink,
+  Files,
 } from 'vscode-languageserver/node'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { CompletionProvider, SignatureProvider } from './completions'
@@ -122,6 +123,7 @@ async function getSourcesFromSettings(): Promise<string[]> {
   if (folders !== null) {
     if (folders.length > 0) {
       const workspaceroot = URItoVSCodeURI(folders[0].uri)
+      const rootpath = Files.uriToFilePath(workspaceroot) ?? ''
       const item: ConfigurationItem = {
         scopeUri: workspaceroot,
         section: 'beebvsc',
@@ -131,7 +133,7 @@ async function getSourcesFromSettings(): Promise<string[]> {
       if (typeof filename === 'string') {
         // prefix the workspace root if this is not an absolute path
         if (!path.isAbsolute(filename)) {
-          filename = URItoVSCodeURI(path.join(workspaceroot, filename))
+          filename = URItoVSCodeURI(path.join(rootpath, filename))
         } else {
           filename = URItoVSCodeURI(filename)
         }
@@ -140,7 +142,7 @@ async function getSourcesFromSettings(): Promise<string[]> {
         // prefix the workspace root if this is not an absolute path
         filename = filename.map((file: string) => {
           if (!path.isAbsolute(file)) {
-            return URItoVSCodeURI(path.join(workspaceroot, file))
+            return URItoVSCodeURI(path.join(rootpath, file))
           }
           return URItoVSCodeURI(file)
         })

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -165,6 +165,12 @@ async function ParseFromRoot(textDocument: TextDocument): Promise<void> {
     sourceFilePath = []
   }
 
+  // Check if the document is in the sourceFilePath list
+  if (sourceFilePath.includes(uri)) {
+    await ParseDocument(uri, uri)
+    return
+  }
+
   // Parse each root in turn, until find the one that contains the document
   for (const file of sourceFilePath) {
     await ParseDocument(file, textDocument.uri)


### PR DESCRIPTION
Closes #107, will now produce relative paths in the settings.json file for beebasm targets. Still can process absolute paths for backwards compatibility or if someone manually updates it like that.

Closes #103, no platform specific code anymore as better use of existing path handling functionality within vscode packages.

Closes #106, we now scan the subfolders of the workspace folder to look for source code files to offer relative paths. This also means the E2E testing task should work for any one. Tested on Windows and Mac and seems good.

