### PR TITLE
fix: Rename after Find All References fails

### DIFF
--- a/src/client/test/rename.test.ts
+++ b/src/client/test/rename.test.ts
@@ -1,0 +1,47 @@
+import { Uri, Position, WorkspaceEdit, TextEdit, commands } from 'vscode'
+import * as assert from 'assert'
+import { getDocUri, activate } from './helper'
+
+suite('Should do rename', () => {
+  const docUri = getDocUri('rename.6502')
+
+  test('Rename symbols and labels', async () => {
+    await testRename(docUri, new Position(0, 2), 'newSymbol')
+    await testRename(docUri, new Position(6, 6), 'newLabel')
+  })
+})
+
+// rename.6502 file contents:
+// 0 symbol = %01001010
+// 1 ORG &1000
+// 2 .label
+// 3 {
+// 4 	LDA #symbol
+// 5 	CMP &80
+// 6 	BEQ label
+// 7 }
+
+async function testRename(docUri: Uri, position: Position, newname: string) {
+  await activate(docUri)
+
+  const prepareRenameEdits = (await commands.executeCommand(
+    'vscode.prepareRename',
+    docUri,
+    position,
+  )) as Range | null
+
+  assert.ok(prepareRenameEdits)
+
+  const actualWorkspaceEdits = (await commands.executeCommand(
+    'vscode.executeDocumentRenameProvider',
+    docUri,
+    position,
+    newname,
+  )) as WorkspaceEdit
+
+  assert.equal(actualWorkspaceEdits.entries().length, 1)
+  const edits: TextEdit[] = actualWorkspaceEdits.entries()[0][1]
+  // check list contains reference to new name
+  assert.equal(edits.length, 2)
+  assert.equal(edits[0].newText, newname)
+}

--- a/src/client/test/testFixture/main.6502
+++ b/src/client/test/testFixture/main.6502
@@ -3,3 +3,4 @@
 
 INCLUDE "completion.6502"
 INCLUDE "diagnostics.6502"
+INCLUDE "rename.6502"

--- a/src/client/test/testFixture/rename.6502
+++ b/src/client/test/testFixture/rename.6502
@@ -1,0 +1,8 @@
+symbol = %01001010
+ORG &1000
+.label
+{
+	LDA #symbol
+	CMP &80
+	BEQ label
+}

--- a/src/server/symbolhandler.ts
+++ b/src/server/symbolhandler.ts
@@ -169,14 +169,17 @@ export class SymbolProvider {
     if (textDocument) {
       const currentLine = textDocument.getText().split(/\r?\n/g)[location.line] // Would be nice to get just the line using a range argument but not sure what end position would be
       const refs = FindReferences(currentLine, uri, location)
+      const allRefs: Location[] = []
       const definition = FindDefinition(currentLine, uri, location)
       if (definition !== null) {
-        if (refs === null) {
-          return [definition]
-        }
-        refs.push(definition)
+        allRefs.push(definition)
       }
-      return refs
+      if (refs !== null) {
+        for (const ref of refs) {
+          allRefs.push(ref)
+        }
+      }
+      return allRefs
     }
     return null
   }


### PR DESCRIPTION
Fixes #112 

Also adds a couple of E2E tests for renaming functionality.