### PR TITLE
Label names take priority over keywords

### DIFF
--- a/syntaxes/6502.tmLanguage.json
+++ b/syntaxes/6502.tmLanguage.json
@@ -7,13 +7,13 @@
   "name": "6502/BeebAsm Assembly",
   "patterns": [
     { "include": "#comments" },
+    { "include": "#labels" },
     { "include": "#constants" },
     { "include": "#control" },
     { "include": "#6502" },
     { "include": "#beebasm" },
     { "include": "#quotes" },
-    { "include": "#operators" },
-    { "include": "#labels" }
+    { "include": "#operators" }
   ],
   "repository": {
     "6502": {


### PR DESCRIPTION
Fixes #122 
Seems too easy :). It does make sense though, labels should be unabiguous due to starting with a full stop.