### PR TITLE
Debug mode doesn't pause/resume emulator on focus change

### DIFF
--- a/src/client/debugger/debugger.ts
+++ b/src/client/debugger/debugger.ts
@@ -38,6 +38,7 @@ import {
   HostMessageDebugCommand,
   HostMessageDebugRequest,
   HostMessageSetBreakpoints,
+  HostMessageSetDebugMode,
   StoppedReason,
 } from '../../types/shared/messages'
 import { Subject } from 'await-notify'
@@ -309,6 +310,10 @@ export class JSBeebDebugSession extends LoggingDebugSession {
     this.loadSourceMap()
     const needToBind = EmulatorPanel.instance === undefined
     EmulatorPanel.show(this.extensionPath, Uri.file(args.diskImage), [])
+    const message: HostMessageSetDebugMode = {
+      command: HostCommand.SetDebugMode,
+    }
+    EmulatorPanel.instance?.notifyClient(message)
     if (needToBind) {
       this.webview = EmulatorPanel.instance?.GetWebview()
       if (this.webview) {
@@ -495,7 +500,6 @@ export class JSBeebDebugSession extends LoggingDebugSession {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     request?: DebugProtocol.Request | undefined,
   ): void {
-    console.log('pauseRequest called')
     const message: HostMessageDebugCommand = {
       command: HostCommand.DebugCommand,
       instruction: { instruction: DebugInstructionType.Pause },
@@ -511,7 +515,6 @@ export class JSBeebDebugSession extends LoggingDebugSession {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     request?: DebugProtocol.Request | undefined,
   ): void {
-    console.log('continueRequest called')
     const message: HostMessageDebugCommand = {
       command: HostCommand.DebugCommand,
       instruction: { instruction: DebugInstructionType.Continue },
@@ -528,7 +531,6 @@ export class JSBeebDebugSession extends LoggingDebugSession {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     request?: DebugProtocol.Request | undefined,
   ): void {
-    console.log('stepInRequest called')
     const message: HostMessageDebugCommand = {
       command: HostCommand.DebugCommand,
       instruction: { instruction: DebugInstructionType.Step },
@@ -544,7 +546,6 @@ export class JSBeebDebugSession extends LoggingDebugSession {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     request?: DebugProtocol.Request | undefined,
   ): void {
-    console.log('nextRequest called')
     const message: HostMessageDebugCommand = {
       command: HostCommand.DebugCommand,
       instruction: { instruction: DebugInstructionType.StepOver },
@@ -560,7 +561,6 @@ export class JSBeebDebugSession extends LoggingDebugSession {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     request?: DebugProtocol.Request | undefined,
   ): void {
-    console.log('stepOutRequest called')
     const message: HostMessageDebugCommand = {
       command: HostCommand.DebugCommand,
       instruction: { instruction: DebugInstructionType.StepOut },
@@ -576,7 +576,6 @@ export class JSBeebDebugSession extends LoggingDebugSession {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     request?: DebugProtocol.Request | undefined,
   ): void {
-    console.log(`${new Date().toLocaleTimeString()} terminateRequest called`)
     EmulatorPanel.instance?.dispose()
     this.sendEvent(new TerminatedEvent())
     this.sendResponse(response)
@@ -587,8 +586,6 @@ export class JSBeebDebugSession extends LoggingDebugSession {
     args: DebugProtocol.ScopesArguments,
   ): void {
     response.body = { scopes: [] }
-    console.log(`${new Date().toLocaleTimeString()} scopesRequest called`)
-    console.log(args)
     // if (args !== null && args.frameId === STACKFRAME) { // STACKFRAME not used as a concept, no locals in assembled code?
     if (args !== null) {
       response.body.scopes.push(new Scope('Registers', VARTYPE.Register, false))
@@ -609,8 +606,6 @@ export class JSBeebDebugSession extends LoggingDebugSession {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     request?: DebugProtocol.Request | undefined,
   ): Promise<void> {
-    // console.log(args)
-    console.log(`${new Date().toLocaleTimeString()} variablesRequest called`)
     const variables: Variable[] = []
     if (args.filter === undefined || args.filter === 'named') {
       if (args.variablesReference === VARTYPE.Register) {
@@ -699,8 +694,6 @@ export class JSBeebDebugSession extends LoggingDebugSession {
     response: DebugProtocol.ReadMemoryResponse,
     { memoryReference, offset = 0, count }: DebugProtocol.ReadMemoryArguments,
   ): Promise<void> {
-    console.log(`${new Date().toLocaleTimeString()} readMemoryRequest called`)
-    // console.log({ memoryReference, offset, count })
     if (memoryReference === 'memory' && count !== 0) {
       if (offset > this.memory.length) {
         response.body = {
@@ -740,9 +733,6 @@ export class JSBeebDebugSession extends LoggingDebugSession {
     args: DebugProtocol.StackTraceArguments,
   ): Promise<void> {
     // const levels = args.levels || 0
-    // log time of call
-    console.log(`${new Date().toLocaleTimeString()} stackTraceRequest called`)
-    // console.log(args)
     const startFrame = args.startFrame || 0
     let frameId = STACKFRAME
     // Get information from emulator
@@ -789,9 +779,6 @@ export class JSBeebDebugSession extends LoggingDebugSession {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     request?: DebugProtocol.Request,
   ): Promise<void> {
-    console.log(
-      `${new Date().toLocaleTimeString()} evaluateRequest '${args.expression}'`,
-    )
     const validExp =
       /([$&%.]|\.\*|\.\^)?([a-z][a-z0-9_]*|\([$&][0-9a-f]+\)|\([0-9]+\))(\.[wd]|\.s[0-9]+)?/gi
     if (args.context === 'watch') {

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -27,6 +27,7 @@ let emulatorView: EmulatorView
 let emulatorInfoBar: EmulatorInfoBar | undefined
 let emulatorToolBar: EmulatorToolBar | undefined
 let emulatorLedBar: EmulatorLedBar | undefined
+let debugMode: boolean = false
 
 async function initialise() {
   sendTelemetryEvent('emulatorActivated')
@@ -89,10 +90,12 @@ window.addEventListener('message', (event) => {
       // We handle focus via window events at the moment
       // since these can arrive before the webview is ready
       // but we may want to do something with visibility or active state later
-      if (message.focus.visible) {
-        emulatorView.resume()
-      } else {
-        emulatorView.suspend()
+      if (!debugMode) {
+        if (message.focus.visible) {
+          emulatorView.resume()
+        } else {
+          emulatorView.suspend()
+        }
       }
       break
     case HostCommand.DiscImages:
@@ -102,7 +105,6 @@ window.addEventListener('message', (event) => {
       //TODO: Listener logic here, in case we need to do something with modified disc images
       break
     case HostCommand.DebugCommand: {
-      console.log('BeebVSC: Debug command received', message)
       const instructiontype = message.instruction.instruction
       if (instructiontype === DebugInstructionType.Pause) {
         emulatorView.suspend()
@@ -160,6 +162,10 @@ window.addEventListener('message', (event) => {
       if (message.breakpoints) {
         emulatorView.SetBreakpoints(message.breakpoints)
       }
+      break
+    }
+    case HostCommand.SetDebugMode: {
+      debugMode = true
       break
     }
   }

--- a/src/types/shared/messages.ts
+++ b/src/types/shared/messages.ts
@@ -117,6 +117,7 @@ export const enum HostCommand {
   DebugCommand = 'debugCommand',
   DebugRequest = 'debugRequest',
   SetBreakpoints = 'setBreakpoints',
+  SetDebugMode = 'setDebugMode',
 }
 
 export interface HostMessageBase extends MessageBase {
@@ -165,6 +166,10 @@ export interface HostMessageSetBreakpoints extends HostMessageBase {
   breakpoints: number[]
 }
 
+export interface HostMessageSetDebugMode extends HostMessageBase {
+  command: HostCommand.SetDebugMode
+}
+
 export type HostMessage =
   | HostMessageDiscImages
   | HostMessageDiscImageChanges
@@ -173,3 +178,4 @@ export type HostMessage =
   | HostMessageDebugCommand
   | HostMessageDebugRequest
   | HostMessageSetBreakpoints
+  | HostMessageSetDebugMode


### PR DESCRIPTION
Introduce a debugMode flag so the emulator web view doesn't try to pause/resume as the focus changes due to interaction of breakpoints. Also remove a few console log messages originally set to help with development and are no longer needed.