### PR TITLE
chore: Add more e2e testing

### DIFF
--- a/src/client/test/completion.test.ts
+++ b/src/client/test/completion.test.ts
@@ -12,10 +12,12 @@ suite('Should do completion', () => {
   const docUri = getDocUri('completion.6502')
 
   test('Completes BeebASM keywords', async () => {
-    await testCompletion(docUri, new Position(0, 0), {
+    await testCompletion(docUri, new Position(3, 0), {
       items: [
         { label: 'PRINT', kind: CompletionItemKind.Method },
         { label: 'STRING$', kind: CompletionItemKind.Function },
+        { label: 'testsymbol', kind: CompletionItemKind.Variable },
+        { label: 'testlabel', kind: CompletionItemKind.Reference },
       ],
     })
   })
@@ -35,12 +37,13 @@ async function testCompletion(
     position,
   )) as CompletionList
 
-  assert.ok(actualCompletionList.items.length >= 2)
+  assert.ok(actualCompletionList.items.length >= 4)
   // check list contains each of the expected items
   expectedCompletionList.items.forEach((expectedItem, _i) => {
     assert.ok(
       actualCompletionList.items.some(
-        (item) => item.label === expectedItem.label,
+        (item) =>
+          item.label === expectedItem.label && item.kind === expectedItem.kind,
       ),
     )
   })

--- a/src/client/test/doclinks.test.ts
+++ b/src/client/test/doclinks.test.ts
@@ -1,0 +1,53 @@
+import { DocumentLink, Position, Uri, Range, commands } from 'vscode'
+import * as assert from 'assert'
+import { getDocUri, activate } from './helper'
+
+suite('Should get document links', () => {
+  const docUri = getDocUri('main.6502')
+
+  test('Expected links', async () => {
+    await testLinks(docUri, [
+      {
+        //Line 3: INCLUDE "completion.6502"
+        range: toRange(3, 9, 3, 24),
+      },
+      {
+        //Line 4: INCLUDE "diagnostics.6502"
+        range: toRange(4, 9, 4, 25),
+      },
+      {
+        //Line 5: INCLUDE "rename.6502"
+        range: toRange(5, 9, 5, 20),
+      },
+    ])
+  })
+})
+
+function toRange(sLine: number, sChar: number, eLine: number, eChar: number) {
+  const start = new Position(sLine, sChar)
+  const end = new Position(eLine, eChar)
+  return new Range(start, end)
+}
+
+async function testLinks(docUri: Uri, expectedDocumentLinks: DocumentLink[]) {
+  await activate(docUri)
+
+  const actualLinks = (await commands.executeCommand(
+    'vscode.executeLinkProvider',
+    docUri,
+  )) as DocumentLink[]
+
+  assert.equal(actualLinks.length, expectedDocumentLinks.length)
+
+  expectedDocumentLinks.forEach((expectedLink, _i) => {
+    assert.ok(
+      actualLinks.some(
+        (item) =>
+          item.range.start.line === expectedLink.range.start.line &&
+          item.range.start.character === expectedLink.range.start.character &&
+          item.range.end.line === expectedLink.range.end.line &&
+          item.range.end.character === expectedLink.range.end.character,
+      ),
+    )
+  })
+}

--- a/src/client/test/hover.test.ts
+++ b/src/client/test/hover.test.ts
@@ -1,0 +1,95 @@
+import { Hover, Position, Uri, commands, MarkdownString } from 'vscode'
+import * as assert from 'assert'
+import { getDocUri, activate } from './helper'
+
+type HoverTest = {
+  position: Position
+  hovers: Hover[]
+}
+
+// symbol = %01001010
+// ORG &1000
+// .label ; comment
+// {
+// 	LDA #symbol
+// 	CMP &80
+// 	BEQ label
+// }
+
+suite('Should get hover information', () => {
+  const docUri = getDocUri('rename.6502')
+
+  test('Expected hovers', async () => {
+    await testHovers(docUri, [
+      {
+        //Line 4: LDA #symbol"
+        position: new Position(4, 6),
+        hovers: [
+          {
+            contents: [
+              new MarkdownString(
+                '```beebasm' + '\n' + 'symbol = %01001010' + '\n```',
+              ),
+            ],
+          },
+        ],
+      },
+      {
+        //Line 5: CMP &80
+        position: new Position(5, 1),
+        hovers: [
+          {
+            contents: [
+              new MarkdownString(
+                [
+                  '## CMP',
+                  '---',
+                  'Compare  ',
+                  'Operation: A - M  ',
+                  'Addressing mode: a8  ',
+                  'Opcode: $C5  ',
+                  'Cycles: 3',
+                  '---',
+                  '|N|V|_|B|D|I|Z|C|',
+                  '|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|',
+                  '|N|-|-|-|-|-|Z|C|',
+                ].join('\n'),
+              ),
+            ],
+          },
+        ],
+      },
+      {
+        //Line 6: BEQ label
+        position: new Position(6, 6),
+        hovers: [
+          {
+            contents: [
+              new MarkdownString(
+                '```beebasm' + '\n' + '.label ; comment' + '\n```',
+              ),
+            ],
+          },
+        ],
+      },
+    ])
+  })
+})
+
+async function testHovers(docUri: Uri, tests: HoverTest[]) {
+  await activate(docUri)
+
+  for (const expectedHover of tests) {
+    const actualHovers = (await commands.executeCommand(
+      'vscode.executeHoverProvider',
+      docUri,
+      expectedHover.position,
+    )) as Hover[]
+    assert.equal(actualHovers.length, expectedHover.hovers.length)
+    console.log((actualHovers[0].contents[0] as MarkdownString).value)
+    const actual = (actualHovers[0].contents[0] as MarkdownString).value
+    const expected = (expectedHover.hovers[0].contents[0] as MarkdownString)
+      .value
+    assert.equal(actual, expected)
+  }
+}

--- a/src/client/test/references.test.ts
+++ b/src/client/test/references.test.ts
@@ -1,0 +1,38 @@
+import { Uri, Position, commands } from 'vscode'
+import * as assert from 'assert'
+import { getDocUri, activate } from './helper'
+
+suite('Should get references', () => {
+  const docUri = getDocUri('rename.6502')
+
+  test('Get references for symbols and labels', async () => {
+    await testFindReferences(docUri, new Position(0, 2), 2)
+    await testFindReferences(docUri, new Position(6, 6), 2)
+  })
+})
+
+// rename.6502 file contents:
+// 0 symbol = %01001010
+// 1 ORG &1000
+// 2 .label ; comment
+// 3 {
+// 4 	LDA #symbol
+// 5 	CMP &80
+// 6 	BEQ label
+// 7 }
+
+async function testFindReferences(
+  docUri: Uri,
+  position: Position,
+  numRefs: number,
+) {
+  await activate(docUri)
+
+  const actualReferences = (await commands.executeCommand(
+    'vscode.executeReferenceProvider',
+    docUri,
+    position,
+  )) as Location[]
+
+  assert.equal(actualReferences.length, numRefs)
+}

--- a/src/client/test/signature.test.ts
+++ b/src/client/test/signature.test.ts
@@ -1,0 +1,31 @@
+import { Uri, Position, SignatureHelp, commands } from 'vscode'
+import * as assert from 'assert'
+import { getDocUri, activate } from './helper'
+
+suite('Should do signature', () => {
+  const docUri = getDocUri('completion.6502')
+  // testsymbol = &6502
+  // ORG &2000
+  // .testlabel
+  test('Provides signature help', async () => {
+    await testSignatureHelp(docUri, new Position(1, 4), 'ORG address')
+  })
+})
+
+async function testSignatureHelp(
+  docUri: Uri,
+  position: Position,
+  expectedSignatureLabel: string,
+) {
+  await activate(docUri)
+
+  // Executing the command `vscode.executeCompletionItemProvider` to simulate triggering completion
+  const actualSignatureHelp = (await commands.executeCommand(
+    'vscode.executeSignatureHelpProvider',
+    docUri,
+    position,
+  )) as SignatureHelp
+
+  assert.equal(actualSignatureHelp.signatures.length, 1)
+  assert.equal(actualSignatureHelp.signatures[0].label, expectedSignatureLabel)
+}

--- a/src/client/test/testFixture/completion.6502
+++ b/src/client/test/testFixture/completion.6502
@@ -1,0 +1,3 @@
+testsymbol = &6502
+ORG &2000
+.testlabel

--- a/src/client/test/testFixture/rename.6502
+++ b/src/client/test/testFixture/rename.6502
@@ -1,6 +1,6 @@
 symbol = %01001010
 ORG &1000
-.label
+.label ; comment
 {
 	LDA #symbol
 	CMP &80


### PR DESCRIPTION
Expand the set of language features covered by the end-to-end testing setup.

Closes #108, although can always add more.

