### PR TITLE
Fix single quoted character and 'equ' highlighting

### DIFF
--- a/syntaxes/6502.tmLanguage.json
+++ b/syntaxes/6502.tmLanguage.json
@@ -110,8 +110,7 @@
     "quotes": {
       "patterns": [
         {
-          "begin": "'",
-          "end": "'",
+          "match": "(?i)'(?:[^']|\\')'",
           "name": "string.quoted.single"
         },
         {

--- a/syntaxes/6502.tmLanguage.json
+++ b/syntaxes/6502.tmLanguage.json
@@ -143,7 +143,7 @@
     "operators": {
       "patterns": [
         {
-          "match": "(?i)[+\\-*/%!|^=~\\:&<>]|equ|\\.(and|x?or|not|(lo|hi)(?=\\s*\\())",
+          "match": "(?i)[+\\-*/%!|^=~\\:&<>]|\\.(and|x?or|not|(lo|hi)(?=\\s*\\())",
           "name": "keyword.operators"
         }
       ]


### PR DESCRIPTION
Restricts the pattern for matching single quotes to have exactly one character between the quotes.

Removes 'equ' from the list of operators as doesn't actually exist and affects highlighting elsewhere.