### PR TITLE
fix: Include all label types in syntax highlighting rules

### DIFF
--- a/syntaxes/6502.tmLanguage.json
+++ b/syntaxes/6502.tmLanguage.json
@@ -90,7 +90,7 @@
     "labels": {
       "patterns": [
         {
-          "match": "(?i)\\.[a-z_]\\S+\\b",
+          "match": "(?i)\\.[a-z_^*]\\S+\\b",
           "name": "entity.other.attribute-name.struct"
         }
       ]


### PR DESCRIPTION
Labels with the format `.*label1` or `.^label2` were not being highlighted according to the label colour.