### PR TITLE
Simplify debouncer

### DIFF
--- a/src/server/debounce.ts
+++ b/src/server/debounce.ts
@@ -28,7 +28,6 @@ export function createDebouncer(
 
     // Set a timer. Only when the user stops typing for `delay` ms will we parse
     timeout = setTimeout(() => {
-      console.log(`Debounced: Running parse for ${document.uri}`)
       func(document, newController.signal).catch((err) => {
         if (err.name !== 'AbortError') console.error(err)
       })

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -204,6 +204,7 @@ async function ParseDocument(
   context: DocumentContext,
 ): Promise<void> {
   console.log(`Parsing ${activeFile} from root ${sourceFilePath}`)
+  const startTime = Date.now()
   // map from uri to diagnostics
   const diagnostics = new Map<string, Diagnostic[]>()
   diagnostics.set(sourceFilePath, [])
@@ -252,7 +253,7 @@ async function ParseDocument(
     uri: activeFile,
     diagnostics: thisDiagnostics,
   })
-  console.log(`Parsing ${activeFile} complete`)
+  console.log(`Parsing ${activeFile} complete in ${Date.now() - startTime} ms`)
 }
 
 connection.onDidChangeWatchedFiles((_change) => {


### PR DESCRIPTION
The debouncer was trying to be too smart, starting parses on first keypress without delay, skipping additional keypresses if they came in fast but still making sure there was a final parse. It worked part of the time but not consistently. This simplifies things to a fairly standard trailing edge parse only which seems very reliable. Also adding some timing info to the console to help keep an eye on performance. 