### PR TITLE
feat: Local label scope

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -37,7 +37,7 @@
 				"${workspaceRoot}/dist/server.js"
 			],
 			"sourceMaps": true,
-			"autoAttachChildProcesses": true,
+			"autoAttachChildProcesses": true
 		}
 	]
 }

--- a/src/client/test/hover.test.ts
+++ b/src/client/test/hover.test.ts
@@ -86,7 +86,6 @@ async function testHovers(docUri: Uri, tests: HoverTest[]) {
       expectedHover.position,
     )) as Hover[]
     assert.equal(actualHovers.length, expectedHover.hovers.length)
-    console.log((actualHovers[0].contents[0] as MarkdownString).value)
     const actual = (actualHovers[0].contents[0] as MarkdownString).value
     const expected = (expectedHover.hovers[0].contents[0] as MarkdownString)
       .value

--- a/src/server/beebasm-ts/lineparser.ts
+++ b/src/server/beebasm-ts/lineparser.ts
@@ -1799,8 +1799,9 @@ export class LineParser {
         // Deal here with symbol assignment
         let bIsConditionalAssignment = false
         const startLoc = { line: this._lineno, character: this._column }
-        const symbolName =
-          this.GetSymbolName() + this._sourceCode.GetSymbolNameSuffix()
+        const symbolName = this._sourceCode.GetScopedSymbolName(
+          this.GetSymbolName(),
+        )
         const endLoc = { line: this._lineno, character: this._column }
 
         if (!this.AdvanceAndCheckEndOfStatement()) {
@@ -1960,8 +1961,9 @@ export class LineParser {
               // const paramName = this._sourceCode.GetScopedSymbolName(
               //   macro.GetParameter(i),
               // )
-              const paramName =
-                macro.GetParameter(i) + this._sourceCode.GetSymbolNameSuffix()
+              const paramName = this._sourceCode.GetScopedSymbolName(
+                macro.GetParameter(i),
+              )
 
               const loc = {
                 uri: this._sourceCode.GetURI(),
@@ -3830,8 +3832,10 @@ export class LineParser {
       // Get the symbol name
       const symbolName = this.GetSymbolName()
       // ...and mangle it according to whether we are in a FOR loop
-      const fullSymbolName =
-        symbolName + this._sourceCode.GetSymbolNameSuffix(target_level)
+      const fullSymbolName = this._sourceCode.GetScopedSymbolName(
+        symbolName,
+        target_level,
+      )
       if (this._context.globalData.IsFirstPass()) {
         // only add the symbol on the first pass
         if (this._context.symbolTable.IsSymbolDefined(fullSymbolName)) {

--- a/src/server/beebasm-ts/lineparser.ts
+++ b/src/server/beebasm-ts/lineparser.ts
@@ -4250,7 +4250,7 @@ export class LineParser {
     // Symbol starts with a valid character
     const oldColumn = this._column
     // Change from c++ original: wait to add suffix after entered for loop
-    const symbolName = this.GetSymbolName() // + this._sourceCode.GetSymbolNameSuffix();
+    const symbolName = this.GetSymbolName()
     // Check variable has not yet been defined
     // Should not need this check since creating a new unique symbol including the new for stack pointer
     // if (this._context.symbolTable.IsSymbolDefined(symbolName)) {

--- a/src/server/beebasm-ts/sourcecode.ts
+++ b/src/server/beebasm-ts/sourcecode.ts
@@ -279,9 +279,22 @@ export class SourceCode {
 
     const i = level - 1
     if (i >= 0) {
-      return `${symbolName}@${this._forStack[i].id}`
+      return `${symbolName}@${this._forStack[i].id}_${this._forStack[i].count}`
     }
     return `${symbolName}@-1` // top level symbol, use consistent suffix to avoid clashes with real symbols that don't have a suffix
+  }
+
+  GetOuterScopedSymbolName(symbolName: string, level: integer = -1): string {
+    // For loops store value in first iteration i.e. the _0 suffix
+    if (level == -1) {
+      level = this._forStackPtr
+    }
+
+    const i = level - 1
+    if (i >= 0) {
+      return `${symbolName}@${this._forStack[i].id}_0`
+    }
+    return `${symbolName}@-1`
   }
 
   GetForCount(): integer {
@@ -324,9 +337,31 @@ export class SourceCode {
     symbolName: string,
     location: Location | null = null,
   ): [boolean, number | string] {
+    const symbolsTried = []
+    // Try full reference i.e. for loop scope and count
     for (let forLevel = this.GetForLevel(); forLevel >= 0; forLevel--) {
       const fullSymbolName = this.GetScopedSymbolName(symbolName, forLevel)
-
+      symbolsTried.push(fullSymbolName)
+      if (this._context.symbolTable.IsSymbolDefined(fullSymbolName)) {
+        // store symbol reference (fullSymbolName and location) in symbol table
+        if (location !== null && this._context.globalData.IsSecondPass()) {
+          // Check if current level is not the first iteration, if so then don't add reference as
+          // otherwise we would end up with multiple references for the same symbol when it's used in a loop
+          let addReference = true
+          if (forLevel - 1 >= 0 && !this._forStack[forLevel - 1].firstPass) {
+            addReference = false
+          }
+          if (addReference) {
+            this._context.symbolTable.AddReference(fullSymbolName, location)
+          }
+        }
+        return [true, this._context.symbolTable.GetSymbol(fullSymbolName)]
+      }
+    }
+    // If didn't match, try outer reference i.e. for loop scope but first iteration value
+    for (let forLevel = this.GetForLevel(); forLevel >= 0; forLevel--) {
+      const fullSymbolName = this.GetOuterScopedSymbolName(symbolName, forLevel)
+      symbolsTried.push(fullSymbolName)
       if (this._context.symbolTable.IsSymbolDefined(fullSymbolName)) {
         // store symbol reference (fullSymbolName and location) in symbol table
         if (location !== null && this._context.globalData.IsSecondPass()) {
@@ -347,7 +382,6 @@ export class SourceCode {
     if (this._context.symbolTable.IsSymbolDefined(symbolName)) {
       return [true, this._context.symbolTable.GetSymbol(symbolName)]
     }
-
     return [false, 0]
   }
 
@@ -541,7 +575,7 @@ export class SourceCode {
     this._forStack[this._forStackPtr - 1].varName = symbolname // Update for stack to include suffix
     this._context.symbolTable.AddSymbol(symbolname, start, loc)
     this._context.symbolTable.PushFor(
-      symbolname,
+      varName,
       start,
       this._uri,
       this._lineNumber,

--- a/src/server/beebasm-ts/sourcecode.ts
+++ b/src/server/beebasm-ts/sourcecode.ts
@@ -272,19 +272,16 @@ export class SourceCode {
     return this._currentMacro
   }
 
-  GetSymbolNameSuffix(level: integer = -1): string {
+  GetScopedSymbolName(symbolName: string, level: integer = -1): string {
     if (level == -1) {
       level = this._forStackPtr
     }
 
-    let suffix = ''
-
-    for (let i = 0; i < level; i++) {
-      // suffix += `@${this._forStack[i].id}_${this._forStack[i].count}`;
-      suffix += `@${this._forStack[i].id}_0` // not finding inner for loop definition without this
+    const i = level - 1
+    if (i >= 0) {
+      return `${symbolName}@${this._forStack[i].id}`
     }
-
-    return suffix
+    return `${symbolName}@-1` // top level symbol, use consistent suffix to avoid clashes with real symbols that don't have a suffix
   }
 
   GetForCount(): integer {
@@ -328,15 +325,27 @@ export class SourceCode {
     location: Location | null = null,
   ): [boolean, number | string] {
     for (let forLevel = this.GetForLevel(); forLevel >= 0; forLevel--) {
-      const fullSymbolName = symbolName + this.GetSymbolNameSuffix(forLevel)
+      const fullSymbolName = this.GetScopedSymbolName(symbolName, forLevel)
 
       if (this._context.symbolTable.IsSymbolDefined(fullSymbolName)) {
         // store symbol reference (fullSymbolName and location) in symbol table
         if (location !== null && this._context.globalData.IsSecondPass()) {
-          this._context.symbolTable.AddReference(fullSymbolName, location)
+          // Check if current level is not the first iteration, if so then don't add reference as
+          // otherwise we would end up with multiple references for the same symbol when it's used in a loop
+          let addReference = true
+          if (forLevel - 1 >= 0 && !this._forStack[forLevel - 1].firstPass) {
+            addReference = false
+          }
+          if (addReference) {
+            this._context.symbolTable.AddReference(fullSymbolName, location)
+          }
         }
         return [true, this._context.symbolTable.GetSymbol(fullSymbolName)]
       }
+    }
+    // Check for built-in symbols like P% since they don't have a level suffix
+    if (this._context.symbolTable.IsSymbolDefined(symbolName)) {
+      return [true, this._context.symbolTable.GetSymbol(symbolName)]
     }
 
     return [false, 0]
@@ -528,7 +537,7 @@ export class SourceCode {
       firstPass: true,
     }
     this._forStackPtr++
-    const symbolname = varName + this.GetSymbolNameSuffix()
+    const symbolname = this.GetScopedSymbolName(varName)
     this._forStack[this._forStackPtr - 1].varName = symbolname // Update for stack to include suffix
     this._context.symbolTable.AddSymbol(symbolname, start, loc)
     this._context.symbolTable.PushFor(

--- a/src/server/beebasm-ts/symboltable.ts
+++ b/src/server/beebasm-ts/symboltable.ts
@@ -81,9 +81,9 @@ export class SymbolTable {
   private _context: DocumentContext
 
   constructor(context: DocumentContext) {
-    this._context = context;
-    this.Reset();
-    this._labelScopes = 0;
+    this._context = context
+    this.Reset()
+    this._labelScopes = 0
   }
 
   // get all symbols where location is not noLocation
@@ -99,34 +99,25 @@ export class SymbolTable {
   // Get all symbols in scope for a particular location
   GetSymbolsByLocation(uri: string, line: number): Map<string, SymbolData> {
     const symbols = new Map<string, SymbolData>()
-    const uriSanitised = uri
     for (const [name, symbolData] of this._map.entries()) {
-      if (!name.includes('@')) {
+      if (name.endsWith('@-1')) {
         // global symbols always included
-        symbols.set(name, symbolData)
+        const justName = this.ScopedSymbolBaseName(name)
+        symbols.set(justName, symbolData)
       } else {
-        if (symbolData.GetLocation().uri === uriSanitised) {
-          // local symbols only included if they are in the same file
-          // and the line number is within the scope of the symbol
-          let suffix = ''
-          for (
-            let scopeLevel = 0;
-            scopeLevel < this._labelScopes;
-            scopeLevel++
+        if (symbolData.GetLocation().uri === uri) {
+          // Extract the scope ID from the symbol name and check
+          // if the given line falls within that scope
+          const id = this.ScopedSymbolId(name)
+          if (
+            id >= 0 &&
+            id < this._scopeDetails.length &&
+            line >= this._scopeDetails[id].startLine &&
+            line <= this._scopeDetails[id].endLine &&
+            this._scopeDetails[id].uri === uri
           ) {
-            if (
-              scopeLevel < this._scopeDetails.length &&
-              line >= this._scopeDetails[scopeLevel].startLine &&
-              line <= this._scopeDetails[scopeLevel].endLine &&
-              this._scopeDetails[scopeLevel].uri === uriSanitised
-            ) {
-              suffix = suffix + `@${scopeLevel}_0`
-              if (name.endsWith(suffix)) {
-                // Strip off the suffix
-                const justName = name.split('@')[0]
-                symbols.set(justName, symbolData)
-              }
-            }
+            const justName = this.ScopedSymbolBaseName(name)
+            symbols.set(justName, symbolData)
           }
         }
       }
@@ -140,30 +131,24 @@ export class SymbolTable {
     line: number,
   ): [SymbolData | undefined, string] {
     // Relies on scopeLevel matching ForScopePtr when each scopeDetail was created
-    let search = ''
-    for (
-      let scopeLevel = this._labelScopes - 1;
-      scopeLevel >= 0;
-      scopeLevel--
-    ) {
+    // Search scopes from innermost (highest ID) to outermost
+    for (let scopeId = this._scopeDetails.length - 1; scopeId >= 0; scopeId--) {
+      const scope = this._scopeDetails[scopeId]
       if (
-        scopeLevel < this._scopeDetails.length &&
-        line >= this._scopeDetails[scopeLevel].startLine &&
-        line <= this._scopeDetails[scopeLevel].endLine &&
-        this._scopeDetails[scopeLevel].uri === uri
+        scope.uri === uri &&
+        line >= scope.startLine &&
+        line <= scope.endLine
       ) {
-        search = `@${scopeLevel}_0` + search
+        const search = `${symbolname}@${scopeId}`
+        if (this.IsSymbolDefined(search)) {
+          return [this._map.get(search), search]
+        }
       }
     }
-    search = symbolname + search
-    if (this.IsSymbolDefined(search)) {
-      // console.log("Found symbol " + search);
-      return [this._map.get(search), search]
-    }
     // now check global level (no suffix after symbol name and need exact match)
-    if (this.IsSymbolDefined(symbolname)) {
-      // console.log("Found symbol " + symbolname);
-      return [this._map.get(symbolname), symbolname]
+    const globalSearch = `${symbolname}@-1`
+    if (this.IsSymbolDefined(globalSearch)) {
+      return [this._map.get(globalSearch), globalSearch] // need full name as second part of return value?
     }
     return [undefined, '']
   }
@@ -238,8 +223,6 @@ export class SymbolTable {
   }
 
   AddLabel(symbol: string): void {
-    // Note: this data is not used (beebasm uses it for dumping label list to file)
-    // Keeping around for now in case it's useful in debugging
     if (this._context.globalData.IsSecondPass()) {
       const addr = this._context.objectCode.GetPC()
       const identifier =
@@ -329,6 +312,7 @@ export class SymbolTable {
     // Only interested in user defined symbols with numeric values
     // Since these might represent memory locations
     // Could further filter for non-integer values, negative values, etc.
+    // Should remove FOR loop counters too since definitely not memory locations, but how to identify them?
     for (const [name, symbolData] of this._map.entries()) {
       if (!symbolData.IsLabel() && symbolData.GetLocation() !== noLocation) {
         if (typeof symbolData.GetValue() === 'number') {
@@ -338,5 +322,18 @@ export class SymbolTable {
     }
 
     return symbols
+  }
+
+  // Helpers to extract parts from a scoped symbol name string
+  ScopedSymbolBaseName(scopedName: string): string {
+    const atIndex = scopedName.indexOf('@')
+    return atIndex === -1 ? scopedName : scopedName.substring(0, atIndex)
+  }
+
+  ScopedSymbolId(scopedName: string): number {
+    const atIndex = scopedName.indexOf('@')
+    if (atIndex === -1) return -1
+    const underscoreIndex = scopedName.indexOf('_', atIndex)
+    return parseInt(scopedName.substring(atIndex + 1, underscoreIndex))
   }
 }

--- a/src/server/beebasm-ts/symboltable.ts
+++ b/src/server/beebasm-ts/symboltable.ts
@@ -139,7 +139,7 @@ export class SymbolTable {
         line >= scope.startLine &&
         line <= scope.endLine
       ) {
-        const search = `${symbolname}@${scopeId}`
+        const search = `${symbolname}@${scopeId}_0`
         if (this.IsSymbolDefined(search)) {
           return [this._map.get(search), search]
         }
@@ -258,17 +258,17 @@ export class SymbolTable {
       this._lastLabel!._scope = this._labelScopes
       this._scopeDetails.push({ uri: uri, startLine: startLine, endLine: -1 })
       this._labelScopes++
-      this._labelStack.push(this._lastLabel!)
+      this._labelStack.push({ ...this._lastLabel! })
     }
   }
 
   PopScope(endLine = -1, forID = -1): void {
     if (this._context.globalData.IsSecondPass()) {
       this._labelStack.pop()
-      this._lastLabel =
+      this._lastLabel = this._lastLabel =
         this._labelStack.length === 0
           ? { _addr: 0, _scope: 0, _identifier: '' }
-          : this._labelStack[this._labelStack.length - 1]
+          : { ...this._labelStack[this._labelStack.length - 1] }
       if (forID !== -1) {
         this._scopeDetails[forID].endLine = endLine
       }
@@ -293,7 +293,7 @@ export class SymbolTable {
         this._scopeDetails.push({ uri: uri, startLine: startLine, endLine: -1 })
       }
       this._labelScopes++
-      this._labelStack.push(this._lastLabel!)
+      this._labelStack.push({ ...this._lastLabel! })
     }
   }
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,8 +1,6 @@
 import {
   createConnection,
   Diagnostic,
-  DiagnosticSeverity,
-  DiagnosticTag,
   ProposedFeatures,
   InitializeParams,
   TextDocumentSyncKind,
@@ -15,7 +13,11 @@ import { TextDocument } from 'vscode-languageserver-textdocument'
 import { CompletionProvider, SignatureProvider } from './completions'
 import { SourceMapFile } from '../types/shared/debugsource'
 import { SourceFile } from './beebasm-ts/sourcefile'
-import { RenameProvider, SymbolProvider } from './symbolhandler'
+import {
+  checkUnusedSymbols,
+  RenameProvider,
+  SymbolProvider,
+} from './symbolhandler'
 import { FileHandler, URItoVSCodeURI } from './filehandler'
 import { HoverProvider } from './hoverprovider'
 import { SemanticTokensProvider } from './semantictokenprovider'
@@ -335,41 +337,6 @@ async function SaveSourceMap(
     return null
   }
   return mapFile
-}
-
-function checkUnusedSymbols(
-  context: DocumentContext,
-  activeFile: string,
-): Diagnostic[] {
-  const unusedDiagnostics: Diagnostic[] = []
-  const symbols = context.symbolTable.GetSymbols()
-
-  for (const [name, symbolData] of symbols.entries()) {
-    // Only check symbols defined in the active file
-    if (symbolData.GetLocation().uri !== activeFile) continue
-
-    // Skip labels (only check constant declarations)
-    if (symbolData.IsLabel()) continue
-
-    // Skip built-in symbols (empty uri)
-    if (symbolData.GetLocation().uri === '') continue
-
-    // Check if symbol has any references
-    const refs = context.symbolTable.GetReferences(name)
-    if (refs === undefined || refs.length === 0) {
-      // Strip scope suffix from name for display (e.g., "symbol@0" -> "symbol")
-      const displayName = name.includes('@') ? name.split('@')[0] : name
-      unusedDiagnostics.push({
-        severity: DiagnosticSeverity.Hint,
-        range: symbolData.GetLocation().range,
-        message: `'${displayName}' is declared but never used`,
-        source: 'vscode-beebasm',
-        tags: [DiagnosticTag.Unnecessary],
-      })
-    }
-  }
-
-  return unusedDiagnostics
 }
 
 // Setup completions handling

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -135,7 +135,8 @@ async function getInfoFromSettings(): Promise<string[]> {
       const settings = await connection.workspace.getConfiguration(item)
       const inlayHints = settings['enableInlayHints']
       if (inlayHints !== undefined) {
-        inlayHintsProvider.enabled = typeof inlayHints === 'string' ? parse(inlayHints) : inlayHints
+        inlayHintsProvider.enabled =
+          typeof inlayHints === 'string' ? parse(inlayHints) : inlayHints
       }
       let filename = settings['sourceFile']
       if (typeof filename === 'string') {
@@ -318,7 +319,12 @@ async function SaveSourceMap(
   })
   output.sources = FileHandler.Instance.GetURIRefs()
   output.labels = context.symbolTable.GetAllLabels()
-  output.symbols = context.symbolTable.GetAllSymbols()
+  // remove trailing '@-1' from symbols at global level for readability (e.g., "symbol@-1" -> "symbol")
+  const allSymbols = context.symbolTable.GetAllSymbols()
+  Object.keys(allSymbols).forEach((key) => {
+    const newKey = key.endsWith('@-1') ? key.slice(0, -3) : key
+    output.symbols[newKey] = allSymbols[key]
+  })
 
   const sourceMapString = JSON.stringify(output, null, 2)
 

--- a/src/server/symbolhandler.ts
+++ b/src/server/symbolhandler.ts
@@ -16,7 +16,7 @@ import { DocumentContext } from './documentContext'
 import { FileHandler, URItoReference } from './filehandler'
 
 export class RenameProvider {
-  constructor() { }
+  constructor() {}
 
   onPrepareRename(params: PrepareRenameParams): Range | null {
     const textDocument = FileHandler.Instance.GetDocumentText(
@@ -66,7 +66,7 @@ export class RenameProvider {
     if (symbolname === null) {
       return null
     }
-    const [matched, _] = context.symbolTable.GetSymbolByLine(
+    const [matched, fullSymbolName] = context.symbolTable.GetSymbolByLine(
       symbolname,
       uri,
       position.line,
@@ -74,7 +74,7 @@ export class RenameProvider {
     if (matched === undefined) {
       return null
     }
-    const references = context.symbolTable.GetReferences(symbolname)
+    const references = context.symbolTable.GetReferences(fullSymbolName)
     if (references === undefined) {
       return null
     }
@@ -118,7 +118,7 @@ export class RenameProvider {
 }
 
 export class SymbolProvider {
-  constructor() { }
+  constructor() {}
 
   // TODO - consider to change symbol to type outerLabel.innerLabel instead of label_@...
   // Might not be possible, depends on label style of programmer
@@ -134,7 +134,7 @@ export class SymbolProvider {
       symbols.forEach((symboldata, symbolname) => {
         if (symboldata.GetLocation().uri === uri) {
           symbolList.push({
-            name: symbolname,
+            name: this.JustSymbolName(symbolname),
             detail: '',
             kind: symboldata.IsLabel()
               ? SymbolKind.Function
@@ -160,6 +160,14 @@ export class SymbolProvider {
       return symbolList
     }
     return null
+  }
+
+  private JustSymbolName(fullSymbolName: string): string {
+    // if the symbol name is global scope i.e. ends with @-1 then just return the base name without the scope suffix
+    if (fullSymbolName.endsWith('@-1')) {
+      return fullSymbolName.slice(0, -3)
+    }
+    return fullSymbolName
   }
 
   onReferences(params: ReferenceParams): Location[] | null {
@@ -202,7 +210,7 @@ export class SymbolProvider {
   }
 }
 
-function GetTargetedSymbol(
+export function GetTargetedSymbol(
   currentLine: string,
   location: Position,
 ): string | null {

--- a/src/server/symbolhandler.ts
+++ b/src/server/symbolhandler.ts
@@ -160,7 +160,17 @@ export class SymbolProvider {
           })
         }
       })
-      return symbolList
+
+      // Deduplicate symbols that appear multiple times due to FOR loop iterations
+      // Keep only the first occurrence of each symbol at each location
+      const seenSymbols = new Map<string, DocumentSymbol>()
+      for (const symbol of symbolList) {
+        const key = this.createSymbolKey(symbol)
+        if (!seenSymbols.has(key)) {
+          seenSymbols.set(key, symbol)
+        }
+      }
+      return Array.from(seenSymbols.values())
     }
     return null
   }
@@ -171,6 +181,19 @@ export class SymbolProvider {
       return fullSymbolName.slice(0, -3)
     }
     return fullSymbolName
+  }
+
+  private getBaseSymbolName(displayName: string): string {
+    // Extract the base name (everything before @)
+    // E.g., "n@1_0" -> "n", "myVar" -> "myVar"
+    const atIndex = displayName.indexOf('@')
+    return atIndex > 0 ? displayName.substring(0, atIndex) : displayName
+  }
+
+  private createSymbolKey(symbol: DocumentSymbol): string {
+    // Create composite key: baseName|line:character
+    const baseName = this.getBaseSymbolName(symbol.name)
+    return `${baseName}|${symbol.range.start.line}:${symbol.range.start.character}`
   }
 
   onReferences(params: ReferenceParams): Location[] | null {

--- a/src/server/symbolhandler.ts
+++ b/src/server/symbolhandler.ts
@@ -1,4 +1,7 @@
 import {
+  Diagnostic,
+  DiagnosticSeverity,
+  DiagnosticTag,
   Location,
   Position,
   Range,
@@ -208,6 +211,48 @@ export class SymbolProvider {
     }
     return null
   }
+}
+
+export function checkUnusedSymbols(
+  context: DocumentContext,
+  activeFile: string,
+): Diagnostic[] {
+  const unusedDiagnostics: Diagnostic[] = []
+  const symbols = context.symbolTable.GetSymbols()
+
+  for (const [name, symbolData] of symbols.entries()) {
+    // Only check symbols defined in the active file
+    if (symbolData.GetLocation().uri !== activeFile) continue
+
+    // Skip labels (only check constant declarations)
+    if (symbolData.IsLabel()) continue
+
+    // Skip built-in symbols (PI, P%, TRUE, FALSE, CPU)
+    if (
+      name === 'PI' ||
+      name === 'P%' ||
+      name === 'TRUE' ||
+      name === 'FALSE' ||
+      name === 'CPU'
+    ) {
+      continue
+    }
+    // Check if symbol has any references
+    const refs = context.symbolTable.GetReferences(name)
+    if (refs === undefined || refs.length === 0) {
+      // Strip scope suffix from name for display (e.g., "symbol@0" -> "symbol")
+      const displayName = name.includes('@') ? name.split('@')[0] : name
+      unusedDiagnostics.push({
+        severity: DiagnosticSeverity.Hint,
+        range: symbolData.GetLocation().range,
+        message: `'${displayName}' is declared but never used`,
+        source: 'vscode-beebasm',
+        tags: [DiagnosticTag.Unnecessary],
+      })
+    }
+  }
+
+  return unusedDiagnostics
 }
 
 export function GetTargetedSymbol(

--- a/src/server/test/tests.ts
+++ b/src/server/test/tests.ts
@@ -161,6 +161,7 @@ suite('LineParser', function () {
     test('Test local symbol reference', testLocalSymbolReference)
     test('Test repeated for symbol', testRepeatedForSymbol)
     test('Test multiple files', testMultipleFiles)
+    test('Test P% forward reference', testPCForwardReference)
   })
 
   suite('Commands', function () {
@@ -202,7 +203,7 @@ suite('LineParser', function () {
       'Test multiple statements on line',
       testSourceMapInfoMultipleStatements,
     )
-    test('Test inside of for loop', testSourcMapInfoForLoop)
+    test('Test inside of for loop', testSourceMapInfoForLoop)
     test('Test inside macro call', testSourceMapInfoInsideMacro)
     test(
       'Test inside macro with preceding code',
@@ -232,6 +233,7 @@ suite('LineParser', function () {
       'Test multiple unused constants',
       testMultipleUnusedConstantsAreAllFlagged,
     )
+    test('Test nested FOR loops', testUsedConstantsInNestedForLoops)
   })
 
   suite('Evaluate macro parameters in outer scope', function () {
@@ -645,7 +647,6 @@ PUTTEXT "BOOT.txt", "!BOOT", &FFFF
 SAVE "code", start, end`
   Run2Passes(code)
   const labels = context.symbolTable.GetAllLabels()
-  console.log(labels)
 
   // check labels contains '.start', '.loop', '.exit', '.end'
   assert.ok(labels['.start'] !== undefined)
@@ -691,7 +692,7 @@ function testSkipAndOrg() {
 
 function testForLoop() {
   const code = `
-  FOR n, 0, 10
+  FOR n, 1, 2
   LDA #n
   NEXT`
   for (let pass = 0; pass < 2; pass++) {
@@ -758,7 +759,7 @@ NEXT`
     context,
   )
   sourceCode.Process()
-  assert.equal(diagnostics.get('')!.length, 0)
+  assert.equal(diagnostics.get('')!.length, 0, diagnostics.get('')![0]?.message)
 }
 
 function testAssembler1() {
@@ -891,10 +892,10 @@ function testSymbolLocation() {
   )
   input.Process()
   const syms = context.symbolTable.GetSymbols()
-  let loc = syms.get('a')!.GetLocation()
+  let loc = syms.get('a@-1')!.GetLocation()
   assert.equal(loc.range.start.character, 0)
   assert.equal(loc.range.end.character, 1)
-  loc = syms.get('b')!.GetLocation()
+  loc = syms.get('b@-1')!.GetLocation()
   assert.equal(loc.range.start.character, 5)
   assert.equal(loc.range.end.character, 6)
 }
@@ -1102,6 +1103,16 @@ NEXT`
   assert.equal(result!.range.start.character, 4)
 }
 
+function testPCForwardReference() {
+  const code = `
+SEC
+BCS P% + 2
+INC &80
+INC &81`
+  Run2Passes(code)
+  assert.equal(diagnostics.get('')!.length, 0, diagnostics.get('')![0]?.message)
+}
+
 function testAssertFails() {
   const code = `
 ASSERT 1==2
@@ -1136,13 +1147,13 @@ b = 7283 << 2
 c = 29658 << -2
 d = -1583 << 3`
   Run2Passes(code)
-  const a = context.symbolTable.GetSymbols().get('a')?.GetValue()
+  const a = context.symbolTable.GetSymbols().get('a@-1')?.GetValue()
   assert.equal(a, -16)
-  const b = context.symbolTable.GetSymbols().get('b')?.GetValue()
+  const b = context.symbolTable.GetSymbols().get('b@-1')?.GetValue()
   assert.equal(b, 29132)
-  const c = context.symbolTable.GetSymbols().get('c')?.GetValue()
+  const c = context.symbolTable.GetSymbols().get('c@-1')?.GetValue()
   assert.equal(c, 7414)
-  const d = context.symbolTable.GetSymbols().get('d')?.GetValue()
+  const d = context.symbolTable.GetSymbols().get('d@-1')?.GetValue()
   assert.equal(d, -12664)
 }
 
@@ -1570,7 +1581,7 @@ LDA #10: STA &80`
   assert.equal(info?.parent, null)
 }
 
-function testSourcMapInfoForLoop() {
+function testSourceMapInfoForLoop() {
   const code = `
 ORG &1900
 FOR n, 0, 10
@@ -1899,6 +1910,24 @@ LDA #used`
   Run2Passes(code)
   const unused = checkUnusedSymbols('')
   assert.equal(unused.length, 2)
+}
+
+function testUsedConstantsInNestedForLoops() {
+  const code = `FOR i, 0, 1
+    FOR j, 0, 1
+      b = 9+i-j  
+      LDA #b
+    NEXT
+  NEXT`
+  Run2Passes(code)
+  // print entire symbol table for debugging
+  const symbols = context.symbolTable.GetSymbols()
+  for (const [key, value] of symbols) {
+    console.log(`${key}: ${value.GetValue()}`)
+  }
+  const unused = checkUnusedSymbols('')
+  assert.equal(unused.length, 0, unused![0]?.message)
+  assert.equal(diagnostics.get('')!.length, 0, diagnostics.get('')![0]?.message)
 }
 
 function testMacroParamEval() {

--- a/src/server/test/tests.ts
+++ b/src/server/test/tests.ts
@@ -11,7 +11,11 @@ import {
   TextDocumentPositionParams,
 } from 'vscode-languageserver'
 import { CompletionProvider, SignatureProvider } from '../completions'
-import { FindDefinition, FindReferences } from '../symbolhandler'
+import {
+  FindDefinition,
+  FindReferences,
+  checkUnusedSymbols,
+} from '../symbolhandler'
 import * as AST from '../ast'
 import { InlayHintsProvider } from '../inlayhintsprovider'
 import { FileHandler } from '../filehandler'
@@ -50,46 +54,6 @@ function Run2Passes(code: string) {
     )
     input.Process()
   }
-}
-
-// Helper to check for unused symbols (mirrors server.ts implementation)
-function checkUnusedSymbols(uri: string): Diagnostic[] {
-  const unusedDiagnostics: Diagnostic[] = []
-  const symbols = context.symbolTable.GetSymbols()
-
-  for (const [name, symbolData] of symbols.entries()) {
-    // Only check symbols defined in the specified file
-    if (symbolData.GetLocation().uri !== uri) continue
-
-    // Skip labels (only check constant declarations)
-    if (symbolData.IsLabel()) continue
-
-    // Skip built-in symbols (PI, P%, TRUE, FALSE, CPU)
-    if (
-      name === 'PI' ||
-      name === 'P%' ||
-      name === 'TRUE' ||
-      name === 'FALSE' ||
-      name === 'CPU'
-    ) {
-      continue
-    }
-
-    // Check if symbol has any references
-    const refs = context.symbolTable.GetReferences(name)
-    if (refs === undefined || refs.length === 0) {
-      const displayName = name.includes('@') ? name.split('@')[0] : name
-      unusedDiagnostics.push({
-        severity: DiagnosticSeverity.Hint,
-        range: symbolData.GetLocation().range,
-        message: `'${displayName}' is declared but never used`,
-        source: 'vscode-beebasm',
-        tags: [DiagnosticTag.Unnecessary],
-      })
-    }
-  }
-
-  return unusedDiagnostics
 }
 
 suite('LineParser', function () {
@@ -209,6 +173,7 @@ suite('LineParser', function () {
       'Test inside macro with preceding code',
       SourceMapInfoInsideMacroWithOffset,
     )
+    test('Test labels in FOR loop', SourceMapLabelsInForLoop)
   })
 
   suite('InlayHintsProvider', function () {
@@ -1626,6 +1591,21 @@ TEMP 1`
   assert.equal(info?.line, 6)
 }
 
+function SourceMapLabelsInForLoop() {
+  const code = `
+ORG &1900
+  FOR i, 0, 1
+    FOR j, 0, 2
+    .label
+    LDA #i+j
+  NEXT
+NEXT`
+  Run2Passes(code)
+  const labels = context.symbolTable.GetAllLabels()
+  assert.equal(diagnostics.get('')!.length, 0, diagnostics.get('')![0]?.message)
+  assert.equal(Object.keys(labels).length, 6)
+}
+
 function testInlayHintEasy() {
   const code = 'INX'
   const input = new SourceCode(
@@ -1859,7 +1839,7 @@ function testNumberTooBigFalsePositive() {
 function testUnusedGlobalConstant() {
   const code = 'unused = 42'
   Run2Passes(code)
-  const unused = checkUnusedSymbols('')
+  const unused = checkUnusedSymbols(context, '')
   assert.equal(unused.length, 1)
   assert.equal(unused[0].message, "'unused' is declared but never used")
   assert.deepEqual(unused[0].tags, [DiagnosticTag.Unnecessary])
@@ -1870,7 +1850,7 @@ function testUsedGlobalConstantIsNotFlagged() {
   const code = `used = 42
   LDA #used`
   Run2Passes(code)
-  const unused = checkUnusedSymbols('')
+  const unused = checkUnusedSymbols(context, '')
   assert.equal(unused.length, 0)
 }
 
@@ -1879,7 +1859,7 @@ function testUnusedScopedConstantIsFlagged() {
     scoped = 100
   }`
   Run2Passes(code)
-  const unused = checkUnusedSymbols('')
+  const unused = checkUnusedSymbols(context, '')
   assert.equal(unused.length, 1)
   assert.equal(unused[0].message, "'scoped' is declared but never used")
 }
@@ -1890,7 +1870,7 @@ function testUsedScopedConstantIsNotFlagged() {
     LDA #scoped
   }`
   Run2Passes(code)
-  const unused = checkUnusedSymbols('')
+  const unused = checkUnusedSymbols(context, '')
   assert.equal(unused.length, 0)
 }
 
@@ -1898,7 +1878,7 @@ function testLabelsAreNotFlaggedAsUnused() {
   const code = `.unusedLabel
   RTS`
   Run2Passes(code)
-  const unused = checkUnusedSymbols('')
+  const unused = checkUnusedSymbols(context, '')
   assert.equal(unused.length, 0)
 }
 
@@ -1908,7 +1888,7 @@ unused2 = 2
 used = 3
 LDA #used`
   Run2Passes(code)
-  const unused = checkUnusedSymbols('')
+  const unused = checkUnusedSymbols(context, '')
   assert.equal(unused.length, 2)
 }
 
@@ -1920,12 +1900,8 @@ function testUsedConstantsInNestedForLoops() {
     NEXT
   NEXT`
   Run2Passes(code)
-  // print entire symbol table for debugging
-  const symbols = context.symbolTable.GetSymbols()
-  for (const [key, value] of symbols) {
-    console.log(`${key}: ${value.GetValue()}`)
-  }
-  const unused = checkUnusedSymbols('')
+  const unused = checkUnusedSymbols(context, '')
+
   assert.equal(unused.length, 0, unused![0]?.message)
   assert.equal(diagnostics.get('')!.length, 0, diagnostics.get('')![0]?.message)
 }


### PR DESCRIPTION
Closes #186 
Brings in the generic approach for local scoped variables from the 1.11 release of BeebAsm. The implementation is different in a few ways:

- Not using a class object for scoped symbols because can't do the same sort of comparisons with TypeScript that are possible in c++. Stick with old style string concatenation e.g. n@0_1 but with new definitions for how to derive each part.
- FOR loop variables (e.g. n in FOR n,0,1) were defined at parent scope in BeebAsm then the definition removed after the loop finishes. That's fine for assembly but not good for tracking definitions and references. So changed to define at the level of the loop.