### PR TITLE
chore: Bump version to v0.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 See [Releases on Github](https://github.com/simondotm/beeb-vsc/releases) for full release history.
 
-### 0.3.9
+### 0.3.10 (0.3.9 failed)
  - Integrate JSBeeb's rewind panel (press enter to activate thumbnail)
  - Better debug session management
  - Local label scoping updated closer to latest BeebAsm

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "beeb-vsc",
   "displayName": "Beeb VSC",
   "description": "6502 development environment (BBC Micro/BeebAsm)",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "icon": "./assets/icon.png",
   "galleryBanner": {
     "color": "#5c2d91",


### PR DESCRIPTION
Incrementing version since messed up 0.3.9 release process