### PR TITLE
Feat: Return all dianostics found

### DIFF
--- a/src/server/documentContext.ts
+++ b/src/server/documentContext.ts
@@ -12,6 +12,7 @@ export class DocumentContext {
   public objectCode: ObjectCode
   public trees: Map<string, AST[]>
   public links: Map<string, DocumentLink[]>
+  public lastDiagnosticUris: Set<string>
 
   constructor() {
     this.globalData = new GlobalData()
@@ -20,6 +21,7 @@ export class DocumentContext {
     this.objectCode = new ObjectCode(this)
     this.trees = new Map<string, AST[]>()
     this.links = new Map<string, DocumentLink[]>()
+    this.lastDiagnosticUris = new Set<string>()
   }
 
   public reset(): void {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -14,7 +14,7 @@ import { CompletionProvider, SignatureProvider } from './completions'
 import { SourceMapFile } from '../types/shared/debugsource'
 import { SourceFile } from './beebasm-ts/sourcefile'
 import {
-  checkUnusedSymbols,
+  checkUnusedSymbolsByFile,
   RenameProvider,
   SymbolProvider,
 } from './symbolhandler'
@@ -241,29 +241,45 @@ async function ParseDocument(
     )
     input.Process()
   }
-  // Check for unused symbols
-  const unusedDiagnostics = checkUnusedSymbols(context, activeFile)
-  const activeDiagnostics = diagnostics.get(activeFile) ?? []
-  activeDiagnostics.push(...unusedDiagnostics)
-  diagnostics.set(activeFile, activeDiagnostics)
-  // Remove duplicate diagnostics (due to 2-passes)
-  // We keep both passes so that we can report errors that only occur in one pass
-  const currentDiagnostics = diagnostics.get(activeFile) ?? ([] as Diagnostic[])
-  let thisDiagnostics: Diagnostic[] = []
-  thisDiagnostics = currentDiagnostics.filter((value, index) => {
-    const _value = JSON.stringify(value)
-    return (
-      index ===
-      currentDiagnostics.findIndex((obj) => {
-        return JSON.stringify(obj) === _value
-      })
-    )
+  // Check for unused symbols and merge with existing diagnostics for each file
+  const unusedByFile = checkUnusedSymbolsByFile(context)
+  unusedByFile.forEach((unusedDiagnostics, uri) => {
+    const existingDiagnostics = diagnostics.get(uri) ?? []
+    existingDiagnostics.push(...unusedDiagnostics)
+    diagnostics.set(uri, existingDiagnostics)
   })
 
-  connection.sendDiagnostics({
-    uri: activeFile,
-    diagnostics: thisDiagnostics,
+  // Remove duplicate diagnostics per file (due to 2-passes)
+  // We keep both passes so that we can report errors that only occur in one pass
+  diagnostics.forEach((currentDiagnostics, uri) => {
+    const dedupedDiagnostics = currentDiagnostics.filter((value, index) => {
+      const valueKey = JSON.stringify(value)
+      return (
+        index ===
+        currentDiagnostics.findIndex((obj) => {
+          return JSON.stringify(obj) === valueKey
+        })
+      )
+    })
+
+    connection.sendDiagnostics({
+      uri,
+      diagnostics: dedupedDiagnostics,
+    })
   })
+
+  // Clear diagnostics for files that were published in the previous parse,
+  // but are not part of the current parse graph.
+  diagnostics.forEach((_value, uri) => {
+    context.lastDiagnosticUris.delete(uri)
+  })
+  context.lastDiagnosticUris.forEach((uri) => {
+    connection.sendDiagnostics({
+      uri,
+      diagnostics: [],
+    })
+  })
+  context.lastDiagnosticUris = new Set(diagnostics.keys())
   console.log(`Parsing ${activeFile} complete in ${Date.now() - startTime} ms`)
 }
 

--- a/src/server/symbolhandler.ts
+++ b/src/server/symbolhandler.ts
@@ -240,12 +240,18 @@ export function checkUnusedSymbols(
   context: DocumentContext,
   activeFile: string,
 ): Diagnostic[] {
-  const unusedDiagnostics: Diagnostic[] = []
+  const diagnosticsByFile = checkUnusedSymbolsByFile(context)
+  return diagnosticsByFile.get(activeFile) ?? []
+}
+
+export function checkUnusedSymbolsByFile(
+  context: DocumentContext,
+): Map<string, Diagnostic[]> {
+  const diagnosticsByFile = new Map<string, Diagnostic[]>()
   const symbols = context.symbolTable.GetSymbols()
 
   for (const [name, symbolData] of symbols.entries()) {
-    // Only check symbols defined in the active file
-    if (symbolData.GetLocation().uri !== activeFile) continue
+    const symbolUri = symbolData.GetLocation().uri
 
     // Skip labels (only check constant declarations)
     if (symbolData.IsLabel()) continue
@@ -265,17 +271,20 @@ export function checkUnusedSymbols(
     if (refs === undefined || refs.length === 0) {
       // Strip scope suffix from name for display (e.g., "symbol@0" -> "symbol")
       const displayName = name.includes('@') ? name.split('@')[0] : name
-      unusedDiagnostics.push({
+      const diagnostic: Diagnostic = {
         severity: DiagnosticSeverity.Hint,
         range: symbolData.GetLocation().range,
         message: `'${displayName}' is declared but never used`,
         source: 'vscode-beebasm',
         tags: [DiagnosticTag.Unnecessary],
-      })
+      }
+      const fileDiagnostics = diagnosticsByFile.get(symbolUri) ?? []
+      fileDiagnostics.push(diagnostic)
+      diagnosticsByFile.set(symbolUri, fileDiagnostics)
     }
   }
 
-  return unusedDiagnostics
+  return diagnosticsByFile
 }
 
 export function GetTargetedSymbol(


### PR DESCRIPTION
When parsing assembly which has been split across multiple files using `INCLUDE` statements, we were filtering out the diagnostic results to just the actively displayed window. I don't remember having a particular reason for this, but now I see this is inconsistent with other languages in VSCode, so this removes the filters.